### PR TITLE
Form (debouncedValidateField): Set "immediate: false"

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -416,7 +416,7 @@ export default class Form extends React.Component {
    * That applies that in case multiple calls of this method will be executed, each next within the given timeout
    * duration period postpones the method's execution.
    */
-  debounceValidateField = debounce(this.validateField, 300, true)
+  debounceValidateField = debounce(this.validateField, 250, false)
 
   /**
    * Validates the form.


### PR DESCRIPTION
Covers #71.

* Set `immediate: false` for debounced sync validation
* Decrease the debounce timeout to `250` ms