### PR TITLE
Form: Register and validate Field.Radio properly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   extends: ['airbnb-base', 'airbnb-base/legacy'],
   plugins: ['react', 'import', 'mocha'],
-  env: { 
+  env: {
     'mocha': true
   },
   settings: {
@@ -39,6 +39,7 @@ module.exports = {
     'no-param-reassign': 0,
     'import/prefer-default-export': 0,
     'class-methods-use-this': 0,
+    'no-prototype-builtins': 0,
 
     /* React */
     'react/jsx-uses-react': 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-form",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-form",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "React form without boilerplate. Down with the state management. Embrace custom styling, dynamic props, fields grouping, multi-level validation, flexible API, and much more. Everything you may need.",
   "source": "src/index.js",
   "main": "lib/index.js",

--- a/src/Fields/Field.jsx
+++ b/src/Fields/Field.jsx
@@ -179,7 +179,6 @@ export default class Field extends React.Component {
      * Handle direct props updates.
      * When direct props receive new values, those should be updated in the Form's state as well.
      */
-
     const propsPatch = getPropsPatch({
       contextProps,
       nextProps
@@ -301,9 +300,7 @@ export default class Field extends React.Component {
     const { id, className, style } = this.props;
 
     const Component = this.renderElement(this.props, this.contextProps);
-    invariant(Component, `Cannot render the field \`${this.props.name}\` as it doesn't have a renderable element. Make sure to return a React component in "renderElement()" method.`);
-
-    console.log(this.props.name, 'render disabled:', this.contextProps.get('disabled'));
+    invariant(Component, `Cannot render the field \`${this.props.name}\`, no valid React element was returns from its "renderElement()" method.`);
 
     return (
       <Component.type

--- a/src/utils/getPropsPatch.js
+++ b/src/utils/getPropsPatch.js
@@ -1,3 +1,11 @@
+/**
+ * Get props patch.
+ * Returns the diff patch of the exact subscribed props between immutable context props
+ * and mutable direct nextProps. Used during the Field receive props lifecycle method.
+ * @param {Map} contextProps
+ * @param {object} nextProps
+ * @return {object}
+ */
 const subscribedProps = ['initialValue', 'disabled', 'required'];
 
 export default function getPropsPatch({ contextProps, nextProps }) {
@@ -5,6 +13,8 @@ export default function getPropsPatch({ contextProps, nextProps }) {
   if (!nextProps || nextPropsKeys.length === 0) return {};
 
   return subscribedProps.reduce((patch, propName) => {
+    if (!nextProps.hasOwnProperty(propName)) return patch;
+
     const prevValue = contextProps.get(propName);
     const nextValue = nextProps[propName];
 

--- a/stories/FullForm.jsx
+++ b/stories/FullForm.jsx
@@ -9,7 +9,7 @@ export default class FullForm extends React.Component {
     super();
 
     this.state = {
-      gender: 'male'
+      gender: 'pooper'
     };
   }
 
@@ -27,7 +27,7 @@ export default class FullForm extends React.Component {
         messages={ validationMessages }
         action={ this.handleSubmit }>
         <Field.Group name="userInfo">
-          <div>
+          {/* <div>
             <label>
               User name:
               <Field.Input name="username" required />
@@ -46,7 +46,7 @@ export default class FullForm extends React.Component {
               Last name:
               <Field.Input name="firstName" />
             </label>
-          </div>
+          </div> */}
 
           <div>
             <p>Choose gender:</p>
@@ -57,10 +57,19 @@ export default class FullForm extends React.Component {
                 onChange={({ nextValue }) => {
                   console.log('change', nextValue);
                   this.setState({ gender: nextValue });
-                }}
-                checked />
+                }} />
               Male
             </label>
+
+            <label>
+              <Field.Radio
+                name="gender"
+                onChange={({ nextValue }) => this.setState({ gender: nextValue })}
+                value="pooper"
+                checked />
+              Pooper
+            </label>
+
             <label>
               <Field.Radio
                 name="gender"
@@ -80,7 +89,7 @@ export default class FullForm extends React.Component {
           </Field.Select>
         </div>
 
-        <Condition when={({ fields }) => fields.country && fields.country.value === 'UK'}>
+        {/* <Condition when={({ fields }) => fields.country && fields.country.value === 'UK'}>
           <Field.Group name="hobbies">
             <div>
               <p>Your hobbies</p>
@@ -99,7 +108,7 @@ export default class FullForm extends React.Component {
               </label>
             </div>
           </Field.Group>
-        </Condition>
+        </Condition> */}
 
         <button type="submit">Submit</button>
       </Form>


### PR DESCRIPTION
Resolves the `value` and `initialValue` issue for `Field.Radio` during the registration in the Form.

Related to #38 and #101.
However, I cannot say that this is the best solution.