### PR TITLE
Dev/babel polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+    "presets": ["env", "stage-2", "react"],
+    "plugins": [
+        "transform-export-extensions",
+        "transform-class-properties"
+    ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -16,28 +16,5 @@
       "polyfill": false,
       "regenerator": true
     }]
-  ],
-  "env": {
-    "production": {
-      "presets": [
-        ["env", {
-          "modules": false,
-          "targets": {
-            "browsers": "last 2 versions"
-          }
-        }],
-        "react"
-      ],
-      "plugins": [
-        "transform-export-extensions",
-        "transform-class-properties",
-        "transform-object-rest-spread",
-        ["transform-runtime", {
-          "helpers": false,
-          "polyfill": false,
-          "regenerator": true
-        }]
-      ]
-    }
-  }
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -5,12 +5,17 @@
         "browsers": "last 2 versions"
       }
     }],
-    "stage-2",
     "react"
   ],
   "plugins": [
     "transform-export-extensions",
-    "transform-async-to-generator"
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "regenerator": true
+    }]
   ],
   "env": {
     "production": {
@@ -21,8 +26,17 @@
             "browsers": "last 2 versions"
           }
         }],
-        "stage-2",
         "react"
+      ],
+      "plugins": [
+        "transform-export-extensions",
+        "transform-class-properties",
+        "transform-object-rest-spread",
+        ["transform-runtime", {
+          "helpers": false,
+          "polyfill": false,
+          "regenerator": true
+        }]
       ]
     }
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 module.exports = {
-  env: {
-    browser: true
-  },
+  extends: ['airbnb-base', 'airbnb-base/legacy'],
+  plugins: ['react', 'import', 'mocha'],
   parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 7,
@@ -11,10 +10,9 @@ module.exports = {
       modules: true
     }
   },
-  extends: ['airbnb-base', 'airbnb-base/legacy'],
-  plugins: ['react', 'import', 'mocha'],
   env: {
-    'mocha': true
+    browser: true,
+    mocha: true
   },
   settings: {
     'import/resolver': {

--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,12 +1,5 @@
 {
-  "presets": [
-    ["env", {
-      "targets": {
-        "browsers": "last 2 versions"
-      }
-    }],
-    "react"
-  ],
+  "presets": ["env", "react"],
   "plugins": [
     "transform-export-extensions",
     "transform-class-properties",

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import { configure } from '@storybook/react';
 
 function loadStories() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-form",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-form",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "React form without boilerplate. Down with the state management. Embrace custom styling, dynamic props, fields grouping, multi-level validation, flexible API, and much more. Everything you may need.",
   "module": "src/index.js",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/kettanaito/react-advanced-form.git"
   },
   "keywords": [
+    "react",
     "form",
     "react-form",
     "react-advanced-form",
@@ -26,7 +27,8 @@
     "fields group",
     "validation",
     "form validation",
-    "async-validation",
+    "field validation",
+    "async validation",
     "multi-level validation"
   ],
   "license": "MIT",
@@ -42,9 +44,13 @@
     "babel-eslint": "^8.0.3",
     "babel-loader": "^7.1.2",
     "babel-minify-webpack-plugin": "^0.2.0",
+    "babel-plugin-async-to-promises": "^1.0.5",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.10",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "babel-loader": "^7.1.2",
     "babel-minify-webpack-plugin": "^0.2.0",
     "babel-plugin-async-to-promises": "^1.0.5",
-    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["env", "stage-2", "react"]
+}

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["env", "stage-2", "react"]
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,12 @@
-const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
 const packageJson = require('./package.json');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-const babelConfig = JSON.parse(fs.readFileSync('.babelrc'));
-
 /* Environment */
 const DEVELOPMENT = (process.env.NODE_ENV === 'development');
 const PRODUCTION = (process.env.NODE_ENV === 'production');
-
-if (PRODUCTION) {
-  babelConfig.presets[0][1].modules = false;
-}
 
 module.exports = {
   entry: path.resolve(__dirname, packageJson.module),
@@ -46,7 +39,36 @@ module.exports = {
         test: /\.jsx?$/,
         include: path.resolve(__dirname, 'src'),
         exclude: /node_modules/,
-        use: ['babel-loader', 'eslint-loader']
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: DEVELOPMENT,
+              presets: [
+                ['env', {
+                  modules: DEVELOPMENT && 'commonjs',
+                  targets: {
+                    browsers: 'last 2 versions'
+                  }
+                }],
+                'react'
+              ],
+              plugins: [
+                'transform-export-extensions',
+                'transform-class-properties',
+                'transform-object-rest-spread',
+                ['transform-runtime', {
+                  helpers: false,
+                  polyfill: false,
+                  regenerator: true
+                }]
+              ]
+            }
+          },
+          {
+            loader: 'eslint-loader'
+          }
+        ]
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,19 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
 const packageJson = require('./package.json');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
+const babelConfig = JSON.parse(fs.readFileSync('.babelrc'));
+
 /* Environment */
 const DEVELOPMENT = (process.env.NODE_ENV === 'development');
 const PRODUCTION = (process.env.NODE_ENV === 'production');
+
+if (PRODUCTION) {
+  babelConfig.presets[0][1].modules = false;
+}
 
 module.exports = {
   entry: path.resolve(__dirname, packageJson.module),
@@ -25,7 +32,6 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
     }),
-
     PRODUCTION && new BabelMinifyPlugin({
       removeConsole: true,
       mangle: {
@@ -38,7 +44,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        include: `${__dirname}/src`,
+        include: path.resolve(__dirname, 'src'),
         exclude: /node_modules/,
         use: ['babel-loader', 'eslint-loader']
       }


### PR DESCRIPTION
Should cover #122.

* Includes required babel plugins to bundle RAF with async/await transpiled
* Increased library file size (to 56 Kb), however, much less than with the `babel-polyfill` included
* Small re-organizational changes
* Storybook now doesn't rely on `babel-polyfill` either

## TODO
* Fix broken tests (due to compilation errors related to Babel)