### PR TITLE
Dev/radio should update

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -307,6 +307,7 @@ export default class Form extends React.Component {
     const onChangeHandler = fieldProps.get('onChange');
 
     if (isChangeEvent && isControlled) {
+      console.log('is change event and field is controlled - call its own "onChange" handler');
       invariant(onChangeHandler, 'Cannot update the controlled field `%s`. Expected custom `onChange` handler, ' +
       'but received: %s.', fieldProps.get('name'), onChangeHandler);
 
@@ -362,12 +363,16 @@ export default class Form extends React.Component {
       forceProps: true
     });
 
+    console.log('executing native "handleFieldChange"...');
+
     /**
      * Call custom "onChange" handler for uncontrolled fields only.
      * Controlled fields dispatch "onChange" handler at the beginning of "Form.handleFieldChange".
      * There is no need to dispatch the handler method once more.
      */
     if (!isControlled && onChangeHandler) {
+      console.log('field is not controlled and has custom "onChange", calling a callback!');
+
       onChangeHandler({
         event,
         nextValue,

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -307,7 +307,6 @@ export default class Form extends React.Component {
     const onChangeHandler = fieldProps.get('onChange');
 
     if (isChangeEvent && isControlled) {
-      console.log('is change event and field is controlled - call its own "onChange" handler');
       invariant(onChangeHandler, 'Cannot update the controlled field `%s`. Expected custom `onChange` handler, ' +
       'but received: %s.', fieldProps.get('name'), onChangeHandler);
 
@@ -363,16 +362,12 @@ export default class Form extends React.Component {
       forceProps: true
     });
 
-    console.log('executing native "handleFieldChange"...');
-
     /**
      * Call custom "onChange" handler for uncontrolled fields only.
      * Controlled fields dispatch "onChange" handler at the beginning of "Form.handleFieldChange".
      * There is no need to dispatch the handler method once more.
      */
     if (!isControlled && onChangeHandler) {
-      console.log('field is not controlled and has custom "onChange", calling a callback!');
-
       onChangeHandler({
         event,
         nextValue,

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -12,6 +12,7 @@ import { isset, IterableInstance, getComponentName, getPropsPatch, fieldUtils } 
 const defaultOptions = {
   valuePropName: 'value',
   mapPropsToField: ({ fieldRecord }) => fieldRecord,
+  shouldUpdateRecord: null,
   enforceProps: () => ({})
 };
 
@@ -175,7 +176,19 @@ export default function connectField(options) {
         const nextValue = nextProps[valuePropName];
         const prevValue = this.props[valuePropName];
 
-        if (controlled && (nextValue !== prevValue)) {
+        console.groupCollapsed(this.props.name, '@ Field @ componentWillReceiveProps');
+        console.log({ controlled, prevValue, nextValue });
+        console.groupEnd();
+
+        const shouldUpdateRecord = hocOptions.shouldUpdateRecord ? hocOptions.shouldUpdateRecord({
+          nextValue,
+          prevValue,
+          prevProps: this.props,
+          nextProps,
+          contextProps
+        }) : (prevValue !== nextValue);
+
+        if (controlled && shouldUpdateRecord) {
           this.context.handleFieldChange({
             event: {
               nativeEvent: {

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -176,10 +176,6 @@ export default function connectField(options) {
         const nextValue = nextProps[valuePropName];
         const prevValue = this.props[valuePropName];
 
-        console.groupCollapsed(this.props.name, '@ Field @ componentWillReceiveProps');
-        console.log({ controlled, prevValue, nextValue });
-        console.groupEnd();
-
         const shouldUpdateRecord = hocOptions.shouldUpdateRecord ? hocOptions.shouldUpdateRecord({
           nextValue,
           prevValue,

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -307,7 +307,7 @@ export default function connectField(options) {
         const { props, contextProps } = this;
 
         /** Reference to the enforced props from the HOC options */
-        const enforcedProps = hocOptions.enforceProps(props, contextProps);
+        const enforcedProps = hocOptions.enforceProps({ props, contextProps });
 
         /** A mirror reference to "contextProps", an internal field record stored in Form's state */
         const fieldState = contextProps.toJS();

--- a/src/fieldPresets/checkbox.js
+++ b/src/fieldPresets/checkbox.js
@@ -6,7 +6,7 @@ export default {
     checked: !!checked,
     initialValue: checked
   }),
-  enforceProps: (props, contextProps) => ({
+  enforceProps: ({ contextProps }) => ({
     checked: contextProps.get('checked')
   })
 };

--- a/src/fieldPresets/radio.js
+++ b/src/fieldPresets/radio.js
@@ -21,6 +21,18 @@ export default {
 
     return fieldRecord;
   },
+  /**
+   * Should update record.
+   * Determines when it is needed to execute the native "Form.handleFieldChange" during the
+   * "Field.componentWillReceiveProps" for controlled fields.
+   *
+   * This is needed for the Radio field since on "Field.componentWillReceiveProps" the "prevValue" and "nextValue"
+   * will always be the same - Radio field controlled updates do NOT update the value, but a "checked" prop. Regardless,
+   * what should be compared is the next value and the current value in the field's record.
+   */
+  shouldUpdateRecord: ({ nextValue, nextProps, contextProps }) => {
+    return nextProps.checked && (nextValue !== contextProps.get('value'));
+  },
   enforceProps: (props, contextProps) => ({
     value: props.value,
     checked: contextProps.get('controlled') ? props.checked : contextProps.get('checked')

--- a/src/fieldPresets/radio.js
+++ b/src/fieldPresets/radio.js
@@ -33,7 +33,7 @@ export default {
   shouldUpdateRecord: ({ nextValue, nextProps, contextProps }) => {
     return nextProps.checked && (nextValue !== contextProps.get('value'));
   },
-  enforceProps: (props, contextProps) => ({
+  enforceProps: ({ props, contextProps }) => ({
     value: props.value,
     checked: contextProps.get('controlled') ? props.checked : contextProps.get('checked')
   })


### PR DESCRIPTION
Provides the solution for the controlled Radio issue.

## Brief
Radio field is unique because it uses multiple fields with the same name and different values to handle a single value in the field's record, in the form's state.

So, upon field change, its value should always remain as it was, for option A to have `valueA` and option B to still have `valueB`. So the `nextValue !== prevValue` comparison for Radio will always be `false`, since the actual `CustomField.props.value` should never change.

## Solution
* Introduced a custom `shouldUpdateRecord` handler in `createField` options
* Updated the `fieldPresets.radio` to work properly for controlled Radio buttons
* Refined the interface of `createField` options for all methods to use Object-as-argument approch