### PR TITLE
Form (validate): Filter "nextFields" Map instead of reducing it

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fromJS, Map, Iterable } from 'immutable';
+import { fromJS, Iterable, List, Map } from 'immutable';
 
 /* Internal modules */
 import { TValidationRules, TValidationMessages } from './FormProvider';
@@ -581,10 +581,7 @@ export default class Form extends React.Component {
       const { fields: nextFields } = this.state;
 
       /* Reduce the invalid fields to the ordered Array */
-      const invalidFields = nextFields.keys().reduce((invalidFields, fieldName) => {
-        const fieldProps = nextFields.get(fieldName);
-        return fieldProps.expected ? invalidFields : invalidFields.concat(fieldProps);
-      }, []);
+      const invalidFields = List(nextFields.filter(fieldProps => !fieldProps.get('expected')));
 
       /* Call custom callback */
       dispatch(onInvalid, {

--- a/stories/ValidationExample.jsx
+++ b/stories/ValidationExample.jsx
@@ -80,13 +80,13 @@ export default class ValidationExample extends Component {
     return (
       <FormProvider
         rules={ formRules }
-        withImmutable
         messages={ formMessages }>
         <Form
           ref={ form => this.form = form }
           id="default-form-example"
           ref={ form => this.form = form }
           action={ this.handleFormAction }
+          onInvalid={ console.log }
           onSubmitStart={ this.handleSubmitStart }>
 
           <MyInput


### PR DESCRIPTION
* Simplifies the composition of `invalidField` List during `Form.validate()` method.
* Stops relying on `nextFields.key().reduce()`