### PR TITLE
RxProps: Uses alternative interface, recursive proxying, safe fields Map

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     'prefer-promise-reject-errors': 0,
     'no-confusing-arrow': 0,
     'padded-blocks': 0,
+    'no-underscore-dangle': 0,
 
     /* React */
     'react/jsx-uses-react': 2,

--- a/cypress/scenarios/RxProps/Basic.jsx
+++ b/cypress/scenarios/RxProps/Basic.jsx
@@ -11,8 +11,8 @@ export default class RxPropsBasic extends React.Component {
           initialValue="foo" />
         <Input
           name="fieldTwo"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldOne', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldOne.value;
           }} />
       </Form>
     );

--- a/cypress/scenarios/RxProps/Delegated.jsx
+++ b/cypress/scenarios/RxProps/Delegated.jsx
@@ -8,8 +8,8 @@ export default class RxPropsDelegated extends React.Component {
       <Form>
         <Input
           name="fieldOne"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldTwo', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldTwo.value;
           }} />
         <Input
           name="fieldTwo"

--- a/cypress/scenarios/RxProps/Interdependent.jsx
+++ b/cypress/scenarios/RxProps/Interdependent.jsx
@@ -8,13 +8,13 @@ export default class RxPropsDelegated extends React.Component {
       <Form>
         <Input
           name="fieldOne"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldTwo', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldTwo.value;
           }} />
         <Input
           name="fieldTwo"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldOne', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldOne.value;
           }} />
       </Form>
     );

--- a/cypress/scenarios/RxProps/OneTarget.jsx
+++ b/cypress/scenarios/RxProps/OneTarget.jsx
@@ -8,15 +8,15 @@ export default class RxPropsOneTarget extends React.Component {
       <Form>
         <Input
           name="fieldOne"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldTwo', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldTwo.value;
           }} />
         <Input
           name="fieldTwo" />
         <Input
           name="fieldThree"
-          required={({ subscribe }) => {
-            return !!subscribe('fieldTwo', 'value');
+          required={({ fields }) => {
+            return !!fields.fieldTwo.value;
           }} />
       </Form>
     );

--- a/src/utils/ensafeMap.js
+++ b/src/utils/ensafeMap.js
@@ -1,0 +1,10 @@
+/**
+ * Ensures the provided unsafe key paths are set on the fields Map.
+ * That means that upon convertion to mutable Object, those unsafe paths would explicitly
+ * equal to "undefined", instead of throwing an error.
+ */
+export default function ensafeMap(originMap, keyPaths) {
+  return keyPaths.reduce((safeMap, keyPath) => {
+    return safeMap.setIn(keyPath, safeMap.getIn(keyPath));
+  }, originMap);
+}

--- a/src/utils/fieldUtils/getErrorMessages.js
+++ b/src/utils/fieldUtils/getErrorMessages.js
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import { customRulesKey } from './validate';
-import warn from '../warn';
+import warning from '../warning';
 import dispatch from '../dispatch';
 
 function resolveMessage({ messages, rejectedRule, fieldProps }) {
@@ -66,7 +66,7 @@ export default function getErrorMessages({ validationResult, messages, fieldProp
   const overridesExtras = extraKeys && extraKeys.some(extraKey => defaultResolverKeys.includes(extraKey));
 
   /* Warn about keys override */
-  warn(!overridesExtras, 'Extra keys received from the async response %s overlap with the ' +
+  warning(!overridesExtras, 'Extra keys received from the async response %s overlap with the ' +
   'default resolver arguments %s. Note that the overlapping keys will be overriden in the `%s` field ' +
   'message resolver.', JSON.stringify(extraKeys), JSON.stringify(defaultResolverKeys),
   fieldProps.get('name'));

--- a/src/utils/flushFieldRefs.js
+++ b/src/utils/flushFieldRefs.js
@@ -1,0 +1,48 @@
+import ensafeMap from './ensafeMap';
+
+/**
+ * Recursively proxies the given origin. Calls optional "callback" function whenever any property
+ * if the origin is being referenced.
+ * @param {Object} origin
+ * @param {Function} callback
+ * @returns {Proxy}
+ */
+function proxyWithCallback(origin, callback) {
+  return new Proxy(origin, {
+    get(target, propName) {
+      if (callback) callback({ target, propName });
+      return proxyWithCallback({}, callback);
+    }
+  });
+}
+
+/**
+ * Returns the collection of field paths of the fields referenced within the provided method.
+ * @param {Function} method
+ * @param {Object} fields
+ */
+export default function flushFieldRefs(method, { fields, ...restParams }) {
+  const refs = [];
+  const mutableFields = fields.toJS();
+
+  /* Assign a temporary property to state the root level of target Object */
+  mutableFields.__IS_ROOT__ = true;
+
+  const fieldsProxy = proxyWithCallback(mutableFields, ({ target, propName }) => {
+    if (target.__IS_ROOT__) {
+      refs.push([]);
+    }
+
+    const refEntry = refs[refs.length - 1];
+    refEntry.push(propName);
+  });
+
+  /* First, execute the method with proxied fields to gather the field path refs */
+  method({ ...restParams, fields: fieldsProxy });
+
+  /* Second, execute the method with missing path refs set to "undefined" to prevent throwing */
+  const safeFields = ensafeMap(fields, refs);
+  const initialValue = method({ ...restParams, fields: safeFields.toJS() });
+
+  return { refs, initialValue };
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,8 @@ export warning from './warning';
 export camelize from './camelize';
 export debounce from './debounce';
 export dispatch from './dispatch';
+export ensafeMap from './ensafeMap';
+export flushFieldRefs from './flushFieldRefs';
 export makeCancelable from './makeCancelable';
 
 /* React utils */

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 /* Primitives */
 export isset from './isset';
-export warn from './warn';
+export warning from './warning';
 export camelize from './camelize';
 export debounce from './debounce';
 export dispatch from './dispatch';

--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -4,6 +4,8 @@
  * @param {string} message
  * @param {any[]} optionalParams
  */
-export default function warn(testValue, message, ...optionalParams) {
-  if (!testValue) console.warn(message, ...optionalParams);
+import util from 'util';
+
+export default function warning(testValue, message, ...params) {
+  if (!testValue) console.warn(util.format(message, ...params));
 }

--- a/stories/GroupedFields.jsx
+++ b/stories/GroupedFields.jsx
@@ -30,16 +30,10 @@ export default class GroupedFields extends React.Component {
         <Field.Group name="groupName">
           <Input
             name="firstName"
-            label="First name"
-            required={({ subscribe }) => {
-              return !!subscribe('groupName', 'lastName', 'value');
-            }} />
+            label="First name" />
           <Input
             name="lastName"
-            label="Last name"
-            required={({ subscribe }) => {
-              return !!subscribe('groupName', 'firstName', 'value');
-            }} />
+            label="Last name" />
         </Field.Group>
 
         <Select

--- a/stories/ReactiveProps.jsx
+++ b/stories/ReactiveProps.jsx
@@ -34,7 +34,6 @@ export default class ControlledFields extends Component {
               Product Id:
               <Input
                 name="productId"
-                required={({ fields }) => fields.producerNr && !fields.producerNr.value}
                 asyncRule={({ value: productId }) => {
                   return new Promise(resolve => resolve())
                     .then(() => ({

--- a/stories/RxProps.jsx
+++ b/stories/RxProps.jsx
@@ -62,14 +62,8 @@ export default class Messages extends React.Component {
 
           <Input
             name="rxField"
-            required={({ subscribe }) => {
-              const conditionA = !!subscribe(['fieldOne'], 'value');
-              const conditionB = subscribe(['fieldThree'], 'type') === 'password';
-
-              // const conditionA = fields.fieldOne && !!fields.fieldOne.value;
-              // const conditionB = fields.fieldThree && (fields.fieldThree.type === 'password');
-
-              return conditionA && conditionB;
+            required={({ fields }) => {
+              return fields.fieldOne.value;
             }} />
 
           <Input
@@ -77,7 +71,7 @@ export default class Messages extends React.Component {
             type={ type }
             initialValue="something" />
 
-          <button className="btn btn-secondary" onClick={(event) => {
+          <button onClick={(event) => {
             event.preventDefault();
             this.setState(({ type }) => ({
               type: (type === 'text') ? 'password' : 'text'

--- a/stories/RxProps.jsx
+++ b/stories/RxProps.jsx
@@ -58,6 +58,15 @@ export default class Messages extends React.Component {
 
           <Input
             name="fieldOne"
+            required={({ fields }) => {
+              return !!fields.fieldTwo.value;
+            }} />
+          <Input
+            name="fieldTwo"
+            initialValue="foo" />
+
+          {/* <Input
+            name="fieldOne"
             initialValue="foo" />
 
           <Input
@@ -69,7 +78,7 @@ export default class Messages extends React.Component {
           <Input
             name="fieldThree"
             type={ type }
-            initialValue="something" />
+            initialValue="something" /> */}
 
           <button onClick={(event) => {
             event.preventDefault();

--- a/test/unit/utils/ensafeMap.spec.js
+++ b/test/unit/utils/ensafeMap.spec.js
@@ -1,0 +1,17 @@
+import { Map } from 'immutable';
+import { expect } from 'chai';
+import { ensafeMap } from '../../../src/utils';
+
+describe('ensafeMap', function () {
+  it('Allows to reference non-existing key paths', () => {
+    const origin = Map();
+    const safeMap = ensafeMap(origin, [
+      ['non', 'existing', 'key', 'path'],
+      ['another', 'made', 'up', 'path']
+    ]);
+    const mutableSafeMap = safeMap.toJS();
+
+    expect(mutableSafeMap.non.existing.key.path).to.be.undefined;
+    expect(mutableSafeMap.another.made.up.path).to.be.undefined;
+  });
+});

--- a/test/unit/utils/flushFieldRefs.spec.js
+++ b/test/unit/utils/flushFieldRefs.spec.js
@@ -1,0 +1,31 @@
+import { fromJS } from 'immutable';
+import { expect } from 'chai';
+import { flushFieldRefs } from '../../../src/utils';
+
+describe('flushFieldRefs', function () {
+  it('Flushes referenced field paths properly', () => {
+    const fields = fromJS({ fieldOne: { value: 'foo' } });
+    const method = ({ fields }) => {
+      fields.fieldOne.value;
+      fields.groupOne.fieldOne.required;
+    };
+
+    const { refs } = flushFieldRefs(method, { fields });
+
+    expect(refs).to.be.an.instanceof(Array).with.lengthOf(2);
+    expect(refs[0]).to.deep.equal(['fieldOne', 'value']);
+    expect(refs[1]).to.deep.equal(['groupOne', 'fieldOne', 'required']);
+  });
+
+  it('Resolves initial value properly', () => {
+    const fields = fromJS({ fieldOne: { value: 'foo' } });
+    const method = ({ fields }) => {
+      fields.nonExisting.fieldPath.propName;
+      return fields.fieldOne.value;
+    };
+
+    const { initialValue } = flushFieldRefs(method, { fields });
+
+    expect(initialValue).to.equal(fields.getIn(['fieldOne', 'value']));
+  });
+});

--- a/test/unit/utils/index.js
+++ b/test/unit/utils/index.js
@@ -1,4 +1,9 @@
 describe('utils', function () {
+  describe('Misc', function () {
+    require('./ensafeMap.spec');
+    require('./flushFieldRefs.spec');
+  });
+
   /* Field utils */
   require('./fieldUtils/index.spec');
 


### PR DESCRIPTION
Implements alternative interface for reactive props.

* Removes `subscribe` function to operate with fields subscriptions
* Uses recursive proxying to be able to reference fields like `fields.groupName.fieldName.propName`
* Uses safe Map model to ensure unsafe key references do not break the method they are referenced in
* Adapts the existing implementation and tests to work with the introduced changes