### PR TITLE
Use "regenerator-runtime" instead of "babel-polyfill"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,12 +6,7 @@
     "plugins": [
         "transform-export-extensions",
         "transform-class-properties",
-        "transform-object-rest-spread",
-        ["transform-runtime", {
-            "helpers": false,
-            "polyfill": false,
-            "regenerator": true
-        }]
+        "transform-object-rest-spread"
     ],
     "env": {
         "production": {
@@ -27,12 +22,7 @@
             "plugins": [
                 "transform-export-extensions",
                 "transform-class-properties",
-                "transform-object-rest-spread",
-                ["transform-runtime", {
-                    "helpers": false,
-                    "polyfill": false,
-                    "regenerator": true
-                }]
+                "transform-object-rest-spread"
             ]
         }
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   plugins: ['react', 'import', 'mocha'],
   parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 8,
     ecmaFeatures: {
       classes: true,
       jsx: true,
@@ -12,7 +12,8 @@ module.exports = {
   },
   env: {
     browser: true,
-    mocha: true
+    mocha: true,
+    es6: true
   },
   settings: {
     'import/resolver': {

--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -6,11 +6,6 @@
   "plugins": [
     "transform-export-extensions",
     "transform-class-properties",
-    "transform-object-rest-spread",
-    ["transform-runtime", {
-      "helpers": false,
-      "polyfill": false,
-      "regenerator": true
-    }]
+    "transform-object-rest-spread"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1997,6 +1997,18 @@
         }
       }
     },
+    "babel-plugin-async-to-promises": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-async-to-promises/-/babel-plugin-async-to-promises-1.0.5.tgz",
+      "integrity": "sha1-z9xH0UaM4yvubTiGK/zNK1na8ls=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0",
+        "js-extend": "1.0.1"
+      }
+    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
@@ -3141,6 +3153,17 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bfj-node4": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.3.1.tgz",
+      "integrity": "sha512-SOmOsowQWfXc7ybFARsK3C4MCOWzERaOMV/Fl3Tgjs+5dJWyzo3oa127jL44eMbQiAN17J7SvAs2TRxEScTUmg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "check-types": "7.3.0",
+        "tryer": "1.0.0"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -3600,6 +3623,12 @@
       "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
       "dev": true
     },
+    "check-types": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz",
+      "integrity": "sha1-Ro9XGkQ1wkJI9f0MsOjYfDw0Hn0=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -3912,7 +3941,7 @@
       "dev": true,
       "requires": {
         "commander": "2.11.0",
-        "detective": "4.5.0",
+        "detective": "4.7.1",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
         "iconv-lite": "0.4.19",
@@ -4955,19 +4984,19 @@
       }
     },
     "detective": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
+        "acorn": "5.5.3",
         "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -5115,6 +5144,12 @@
         "dotenv": "4.0.0"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5147,6 +5182,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
       "dev": true
     },
     "electron-to-chromium": {
@@ -6149,6 +6190,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "filesize": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.0.tgz",
+      "integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw==",
       "dev": true
     },
     "finalhandler": {
@@ -7639,6 +7686,24 @@
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
+    "gzip-size": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+      "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -8529,6 +8594,12 @@
       "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
+    "js-extend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-extend/-/js-extend-1.0.1.tgz",
+      "integrity": "sha1-UFUasaxx1LswLkBA675ZAzuisfc=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -8596,6 +8667,12 @@
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
+        "ast-types": {
+          "version": "0.8.12",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+          "dev": true
+        },
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
@@ -8661,6 +8738,32 @@
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
+            },
+            "recast": {
+              "version": "0.10.33",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+              "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+              "dev": true,
+              "requires": {
+                "ast-types": "0.8.12",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.7",
+                "source-map": "0.5.7"
+              }
+            },
+            "regenerator": {
+              "version": "0.8.40",
+              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+              "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+              "dev": true,
+              "requires": {
+                "commoner": "0.10.8",
+                "defs": "1.1.1",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.7",
+                "recast": "0.10.33",
+                "through": "2.3.8"
+              }
             }
           }
         },
@@ -8691,6 +8794,12 @@
             "minimist": "1.2.0",
             "repeating": "1.1.3"
           }
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -10373,6 +10482,12 @@
           "dev": true
         }
       }
+    },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
@@ -12602,41 +12717,86 @@
       "dev": true
     },
     "regenerator": {
-      "version": "0.8.40",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.12.3.tgz",
+      "integrity": "sha512-XeCCWYe042dxPBQ3z5zey9EBUPA7O0zztPnfiC8xYYYhNKXZ6L6XtEb6iZ4nPX5oxElNrXMy4UzlFoldmEEFgA==",
       "dev": true,
       "requires": {
+        "babel-core": "6.26.0",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
         "private": "0.1.7",
-        "recast": "0.10.33",
+        "recast": "0.11.23",
+        "regenerator-preset": "0.11.5",
+        "regenerator-runtime": "0.11.1",
+        "regenerator-transform": "0.12.3",
         "through": "2.3.8"
       },
       "dependencies": {
-        "ast-types": {
-          "version": "0.8.12",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
-          "dev": true
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         },
         "recast": {
-          "version": "0.10.33",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+          "version": "0.11.23",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
           "dev": true,
           "requires": {
-            "ast-types": "0.8.12",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "ast-types": "0.9.6",
+            "esprima": "3.1.3",
             "private": "0.1.7",
             "source-map": "0.5.7"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "regenerator-transform": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
+          "integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+          "dev": true,
+          "requires": {
+            "private": "0.1.7"
+          }
+        }
+      }
+    },
+    "regenerator-preset": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/regenerator-preset/-/regenerator-preset-0.11.5.tgz",
+      "integrity": "sha512-b0xnn9QDcUSOL4d/bRA9CjMsGRgsV5VTth05+iClFmd32vRzzcg/9lQZfC68vtXf07a3thkNqa0yqiaPhGeCAg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "regenerator-transform": "0.12.3"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
+          "integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+          "dev": true,
+          "requires": {
+            "private": "0.1.7"
           }
         }
       }
@@ -13935,6 +14095,12 @@
       "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
       "dev": true
     },
+    "tryer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.0.tgz",
+      "integrity": "sha1-Antp+oIyJeVRys4+8DsR9qs3wdc=",
+      "dev": true
+    },
     "tryor": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
@@ -14532,6 +14698,75 @@
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.1.tgz",
+      "integrity": "sha512-VKUVkVMc6TWVXmF1OxsBXoiRjYiDRA4XT0KqtbLMDK+891VX7FCuklYwzldND8J2upUcHHnuXYNTP+4mSFi4Kg==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "bfj-node4": "5.3.1",
+        "chalk": "2.3.2",
+        "commander": "2.15.1",
+        "ejs": "2.5.7",
+        "express": "4.16.2",
+        "filesize": "3.6.0",
+        "gzip-size": "4.1.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "opener": "1.4.3",
+        "ws": "4.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cypress": "node_modules/.bin/cypress open",
     "build": "NODE_ENV=production BABEL_ENV=production webpack",
     "build:dev": "NODE_ENV=development webpack -w",
-    "test:unit": "mocha --require babel-core/register --require babel-polyfill --exit",
+    "test:unit": "mocha --require babel-core/register --exit",
     "test:integration": "node_modules/.bin/cypress run --spec cypress/integration/index.js",
     "test": "npm run test:unit && npm run test:integration",
     "build-storybook": "build-storybook",
@@ -61,6 +61,8 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.3",
     "babel-minify-webpack-plugin": "^0.3.0",
+    "babel-plugin-async-to-promises": "^1.0.5",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -90,10 +92,12 @@
     "raw-loader": "^0.5.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "regenerator": "^0.12.3",
     "storybook": "^1.0.0",
     "style-loader": "^0.20.2",
     "validator": "^9.4.1",
-    "webpack": "^3.11.0"
+    "webpack": "^3.11.0",
+    "webpack-bundle-analyzer": "^2.11.1"
   },
   "dependencies": {
     "create-prop-types": "^1.0.0",

--- a/src/classes/Sequence.js
+++ b/src/classes/Sequence.js
@@ -35,6 +35,7 @@ export default class Sequence {
   async run() {
     const { entries } = this;
     if (entries.length === 0) return;
+
     let acc = this.initialValue;
 
     for (let index = 0; index < entries.length; index++) {

--- a/src/utils/fieldUtils/validate.js
+++ b/src/utils/fieldUtils/validate.js
@@ -73,7 +73,7 @@ const sequenceIterator = ({ acc, variables, resolved, isLast, breakIteration }) 
  * @param {Map} formRules
  * @return {boolean}
  */
-export default async function validate({ type, fieldProps, fields, form }) {
+export default function validate({ type, fieldProps, fields, form }) {
   // console.groupCollapsed(`fieldUtils @ validate "${fieldProps.get('fieldPath')}"`);
   // console.log('type', type);
   // console.log('fieldProps', Object.assign({}, fieldProps.toJS()));

--- a/src/utils/rxUtils/createSubscriptions.js
+++ b/src/utils/rxUtils/createSubscriptions.js
@@ -16,7 +16,7 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
   rxProps.forEach((resolver, rxPropName) => {
     const { refs } = makeObservable(resolver, resolverArgs, {
       initialCall: true,
-      async subscribe({ nextContextProps, shouldValidate = true }) {
+      subscribe({ nextContextProps, shouldValidate = true }) {
         const refFieldPath = nextContextProps.get('fieldPath');
         const nextFields = form.state.fields.set(refFieldPath, nextContextProps);
         const safeFields = ensafeMap(nextFields, refs);
@@ -29,18 +29,20 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
 
         console.warn('Should update `%s` of `%s` to `%s', rxPropName, subscriberFieldPath.join('.'), nextPropValue);
 
-        const { nextFieldProps: updatedFieldProps } = await form.updateField({
+        const fieldUpdate = form.updateField({
           fieldPath: subscriberFieldPath,
           propsPatch: { [rxPropName]: nextPropValue }
         });
 
         if (shouldValidate) {
-          form.validateField({
-            force: true,
-            fieldPath: subscriberFieldPath,
-            fieldProps: updatedFieldProps,
-            forceProps: true,
-            fields: nextFields
+          fieldUpdate.then(({ nextFieldProps: updatedFieldProps }) => {
+            form.validateField({
+              force: true,
+              fieldPath: subscriberFieldPath,
+              fieldProps: updatedFieldProps,
+              forceProps: true,
+              fields: nextFields
+            });
           });
         }
       }

--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -1,11 +1,12 @@
 /**
- * Calls `console.warn` with the provided message when the `testValue` rejects.
- * @param {boolean} testValue
+ * Calls `console.warn` with the provided message when the condition rejects.
+ * @param {boolean} condition
  * @param {string} message
  * @param {any[]} optionalParams
  */
-import util from 'util';
-
-export default function warning(testValue, message, ...params) {
-  if (!testValue) console.warn(util.format(message, ...params));
+export default function warning(condition, message, ...params) {
+  if (!condition) {
+    let paramIndex = 0;
+    console.warn(message.replace(/%s/g, () => params[paramIndex++]));
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
 const packageJson = require('./package.json');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 /* Environment */
 const DEVELOPMENT = (process.env.NODE_ENV === 'development');
@@ -42,8 +42,7 @@ module.exports = {
           'Condition': true
         }
       }
-    }),
-    new BundleAnalyzerPlugin()
+    })
   ].filter(Boolean),
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,18 +2,20 @@ const path = require('path');
 const webpack = require('webpack');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
 const packageJson = require('./package.json');
-// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 /* Environment */
 const DEVELOPMENT = (process.env.NODE_ENV === 'development');
 const PRODUCTION = (process.env.NODE_ENV === 'production');
 
 module.exports = {
-  entry: path.resolve(__dirname, packageJson.module),
+  entry: [
+    'regenerator-runtime/runtime',
+    path.resolve(__dirname, packageJson.module)
+  ],
   externals: {
     react: 'umd react',
-    immutable: 'umd immutable',
-    // events: 'umd events' // TODO Will this result into a properly working library?
+    immutable: 'umd immutable'
   },
   output: {
     path: __dirname,
@@ -40,7 +42,8 @@ module.exports = {
           'Condition': true
         }
       }
-    })
+    }),
+    new BundleAnalyzerPlugin()
   ].filter(Boolean),
   module: {
     rules: [
@@ -64,6 +67,6 @@ module.exports = {
   },
   devtool: DEVELOPMENT && 'source-map',
   resolve: {
-    extensions: ['.jsx', '.js']
+    extensions: ['.js', '.jsx']
   }
 };


### PR DESCRIPTION
Partially refers to #215.

* Removes "babel-polyfill" from babel plugins for the package bundle
* Decreases the bundle size by ~9 Kb (from 93.4 Kb to 84.3 Kb)