### PR TITLE
"updateField" now accepts an "update" function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # Install the library
-      - run: npm run build
+      - run: npm run build:prod
 
       # Run tests
       - run: npm test

--- a/cypress/integration/components/index.js
+++ b/cypress/integration/components/index.js
@@ -1,4 +1,4 @@
 describe('Components', function () {
-  require('./createField.spec');
-  require('./FormProvider.spec');
+  require('./createField');
+  require('./FormProvider');
 });

--- a/cypress/integration/field-grouping/index.js
+++ b/cypress/integration/field-grouping/index.js
@@ -1,5 +1,5 @@
 describe('Field grouping', function () {
-  require('./SimpleGroup.spec');
-  require('./NestedGroups.spec');
-  require('./SplitGroups.spec');
+  require('./SimpleGroup');
+  require('./NestedGroups');
+  require('./SplitGroups');
 });

--- a/cypress/integration/reactive-props/index.js
+++ b/cypress/integration/reactive-props/index.js
@@ -3,7 +3,7 @@ import { mount } from 'cypress-react-unit-test';
 import BasicScenario from '@examples/reactive-props/Basic';
 import DelegatedScenario from '@examples/reactive-props/Delegated';
 import InterdependentScenario from '@examples/reactive-props/Interdependent';
-import OneTargetScenario from '@examples/reactive-props/SingleTarget';
+import SingleTargetScenario from '@examples/reactive-props/SingleTarget';
 
 describe('Reactive props', function () {
   it('Direct field subscription', () => {
@@ -60,7 +60,7 @@ describe('Reactive props', function () {
   });
 
   it('Multiple fields depending on one target', () => {
-    mount(<OneTargetScenario />);
+    mount(<SingleTargetScenario />);
 
     cy.get('[name="firstName"]').should('not.have.attr', 'required');
     cy.get('[name="fieldThree"]').should('not.have.attr', 'required');

--- a/cypress/integration/validation/SyncValidation/index.spec.jsx
+++ b/cypress/integration/validation/SyncValidation/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
 describe('Synchronous validation', function () {
-  require('./Form.props.rules.spec');
-  require('./Field.props.rule.spec');
+  require('./Form.props.rules');
+  require('./Field.props.rule');
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const webpack = require('@cypress/webpack-preprocessor');
+const webpack = require('webpack');
+const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 
 const webpackOptions = {
   module: {
@@ -18,6 +19,11 @@ const webpackOptions = {
       }
     ]
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    })
+  ],
   resolve: {
     alias: {
       '@examples': path.resolve(__dirname, '../../examples'),
@@ -34,5 +40,5 @@ const options = {
 };
 
 module.exports = (on, config) => {
-  on('file:preprocessor', webpack(options))
+  on('file:preprocessor', webpackPreprocessor(options))
 };

--- a/examples/full/RegistrationForm/RegistrationForm.jsx
+++ b/examples/full/RegistrationForm/RegistrationForm.jsx
@@ -3,12 +3,18 @@ import { Form, Field } from '@lib';
 import { Input } from '@fields';
 
 export default class RegistrationForm extends React.Component {
+  state = {
+    type: 'text'
+  }
+
   registerUser = ({ serialized }) => {
     console.log(serialized);
     return new Promise(resolve => resolve());
   }
 
   render() {
+    const { type } = this.state;
+
     return (
       <Form action={ this.registerUser }>
         <Field.Group name="primaryInfo">
@@ -19,9 +25,14 @@ export default class RegistrationForm extends React.Component {
             required />
         </Field.Group>
 
+        <button onClick={(event) => {
+          event.preventDefault();
+          this.setState(({ type }) => ({ type: (type === 'text') ? 'password' : 'text' }));
+        }}>Toggle type</button>
+
         <Input
           name="userPassword"
-          type="password"
+          type={ type }
           label="Password"
           required />
         <Input

--- a/examples/full/RegistrationForm/RegistrationForm.jsx
+++ b/examples/full/RegistrationForm/RegistrationForm.jsx
@@ -3,18 +3,12 @@ import { Form, Field } from '@lib';
 import { Input } from '@fields';
 
 export default class RegistrationForm extends React.Component {
-  state = {
-    type: 'text'
-  }
-
   registerUser = ({ serialized }) => {
     console.log(serialized);
     return new Promise(resolve => resolve());
   }
 
   render() {
-    const { type } = this.state;
-
     return (
       <Form action={ this.registerUser }>
         <Field.Group name="primaryInfo">
@@ -25,14 +19,9 @@ export default class RegistrationForm extends React.Component {
             required />
         </Field.Group>
 
-        <button onClick={(event) => {
-          event.preventDefault();
-          this.setState(({ type }) => ({ type: (type === 'text') ? 'password' : 'text' }));
-        }}>Toggle type</button>
-
         <Input
           name="userPassword"
-          type={ type }
+          type="password"
           label="Password"
           required />
         <Input

--- a/examples/reactive-props/SingleTarget.jsx
+++ b/examples/reactive-props/SingleTarget.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Form } from '@lib';
 import { Input } from '@fields';
 
-export default class RxPropsOneTarget extends React.Component {
+export default class RxPropsSingleTarget extends React.Component {
   render() {
     return (
       <Form>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build:dev": "NODE_ENV=development webpack",
     "build:storybook": "build-storybook",
     "test:unit": "NODE_ENV=production mocha --require babel-core/register --exit",
-    "test:integration": "node_modules/.bin/cypress run --spec cypress/integration/index.js",
+    "test:integration": "NODE_ENV=production node_modules/.bin/cypress run --spec cypress/integration/index.js",
     "test": "npm run test:unit && npm run test:integration",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -2,7 +2,7 @@ import invariant from 'invariant';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { EventEmitter } from 'events';
-import { fromJS, Iterable, List, Map } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/bufferTime';
 import 'rxjs/add/observable/fromEvent';
@@ -324,13 +324,6 @@ export default class Form extends React.Component {
       update: fieldProps => fieldProps.set('focused', true)
     });
 
-    // const { nextFieldProps, nextFields } = await this.updateField({
-    //   fieldPath: fieldProps.get('fieldPath'),
-    //   propsPatch: {
-    //     focused: true
-    //   }
-    // });
-
     /* Call custom onFocus handler */
     const onFocusHandler = fieldProps.get('onFocus');
     if (!onFocusHandler) return;
@@ -398,21 +391,6 @@ export default class Form extends React.Component {
         .set('validAsync', false)
         // .set('errors', null)
     });
-
-    // const { nextFieldProps: updatedFieldProps } = await this.updateField({
-    //   fieldProps,
-    //   propsPatch: {
-    //     [valuePropName]: nextValue,
-
-    //     /* Reset the validation states as they are irrelevant to the updated value */
-    //     // errors: null,
-    //     validating: false,
-    //     validSync: false,
-    //     validAsync: false,
-    //     validatedSync: false,
-    //     validatedAsync: false
-    //   }
-    // });
 
     /* Cancel any pending async validation due to the field value change */
     if (updatedFieldProps.has('pendingAsyncValidation')) {
@@ -511,15 +489,6 @@ export default class Form extends React.Component {
           .set('validating', true)
       });
 
-      // const { nextFieldProps } = await this.updateField({
-      //   fieldPath,
-      //   propsPatch: {
-      //     errors: null,
-      //     invalid: false,
-      //     validating: true
-      //   }
-      // });
-
       /* Validate the field */
       await this.validateField({ fieldProps: nextFieldProps });
     }
@@ -531,14 +500,6 @@ export default class Form extends React.Component {
         .set('focused', false)
         .set('validating', false)
     });
-
-    // const { nextFields, nextFieldProps } = await this.updateField({
-    //   fieldPath,
-    //   propsPatch: {
-    //     focused: false,
-    //     validating: false
-    //   }
-    // });
 
     /* Call custom onBlur handler */
     const onBlur = nextFieldProps.get('onBlur');
@@ -647,11 +608,6 @@ export default class Form extends React.Component {
         .merge(propsPatch)
         .merge(nextValidityState)
     });
-
-    // return this.updateField({
-    //   fieldProps,
-    //   propsPatch: propsPatch.merge(nextValidityState)
-    // });
   }
 
   /**

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -243,7 +243,7 @@ export default function connectField(options) {
         const { props: prevProps, contextProps: prevContextProps } = this;
         this.contextProps = nextContextProps;
 
-        const fieldPropsChange = camelize(...this.contextProps.get('fieldPath'), 'props', 'change');
+        const fieldPropsChange = camelize(...nextContextProps.get('fieldPath'), 'props', 'change');
 
         this.context.form.eventEmitter.emit(fieldPropsChange, {
           prevProps,

--- a/src/utils/fieldUtils/validateAsync.js
+++ b/src/utils/fieldUtils/validateAsync.js
@@ -36,9 +36,7 @@ export default async function validateAsync({ fieldProps, fields, form }) {
    */
   form.updateField({
     fieldProps,
-    propsPatch: {
-      pendingAsyncValidation: wrappedPromise
-    }
+    update: fieldProps => fieldProps.set('pendingAsyncValidation', wrappedPromise)
   });
 
   const res = await wrappedPromise.itself;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,6 @@ export ensafeMap from './ensafeMap';
 export flattenDeep from './flattenDeep';
 export flushFieldRefs from './flushFieldRefs';
 export makeCancelable from './makeCancelable';
-export makeObservable from './makeObservable';
 
 /* Composite utils */
 export * as CustomPropTypes from './propTypes';

--- a/src/utils/rxUtils/createRulesSubscriptions.js
+++ b/src/utils/rxUtils/createRulesSubscriptions.js
@@ -1,5 +1,5 @@
+import makeObservable from './makeObservable';
 import flushFieldRefs from '../flushFieldRefs';
-import makeObservable from '../makeObservable';
 import getFieldRules from '../formUtils/getFieldRules';
 
 export default function createRulesSubscriptions({ fieldProps, fields, form }) {

--- a/src/utils/rxUtils/createSubscriptions.js
+++ b/src/utils/rxUtils/createSubscriptions.js
@@ -1,5 +1,5 @@
+import makeObservable from './makeObservable';
 import ensafeMap from '../ensafeMap';
-import makeObservable from '../makeObservable';
 
 /**
  * @param {Map} fieldProps
@@ -29,13 +29,13 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
 
         console.warn('Should update `%s` of `%s` to `%s', rxPropName, subscriberFieldPath.join('.'), nextPropValue);
 
-        const fieldUpdate = form.updateField({
+        const fieldUpdated = form.updateField({
           fieldPath: subscriberFieldPath,
-          propsPatch: { [rxPropName]: nextPropValue }
+          update: fieldProps => fieldProps.set(rxPropName, nextPropValue)
         });
 
         if (shouldValidate) {
-          fieldUpdate.then(({ nextFieldProps: updatedFieldProps }) => {
+          fieldUpdated.then(({ nextFieldProps: updatedFieldProps }) => {
             form.validateField({
               force: true,
               fieldPath: subscriberFieldPath,

--- a/src/utils/rxUtils/createSubscriptions.js
+++ b/src/utils/rxUtils/createSubscriptions.js
@@ -27,7 +27,7 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
           form
         }, form.context);
 
-        console.warn('Should update `%s` of `%s` to `%s', rxPropName, subscriberFieldPath.join('.'), nextPropValue);
+        // console.warn('Should update `%s` of `%s` to `%s', rxPropName, subscriberFieldPath.join('.'), nextPropValue);
 
         const fieldUpdated = form.updateField({
           fieldPath: subscriberFieldPath,

--- a/src/utils/rxUtils/makeObservable.js
+++ b/src/utils/rxUtils/makeObservable.js
@@ -1,8 +1,8 @@
 import { Map } from 'immutable';
 import { Observable } from 'rxjs/Observable';
-import { addPropsObserver } from './rxUtils';
-import flushFieldRefs from './flushFieldRefs';
-import camelize from './camelize';
+import addPropsObserver from './addPropsObserver';
+import flushFieldRefs from '../flushFieldRefs';
+import camelize from '../camelize';
 
 /**
  * Returns the formatted references in a { [fieldPath]: props } format.
@@ -35,13 +35,7 @@ function formatRefs(refs) {
  * @param {Object} observerOptions
  * @returns {Subscription}
  */
-function createObserver({
-  fieldPath,
-  props,
-  form,
-  subscribe,
-  observerOptions
-}) {
+function createObserver({ fieldPath, props, form, subscribe, observerOptions }) {
   return addPropsObserver({
     fieldPath,
     props,
@@ -56,6 +50,12 @@ function createObserver({
   }).subscribe(subscribe);
 }
 
+/**
+ * Makes the provided method observable, subscribing to props changes of the referenced fields in the method.
+ * @param {Function} method
+ * @param {Object<argName: argValue>} methodArgs
+ * @param {Options} options
+ */
 export default function makeObservable(method, methodArgs, { observerOptions, subscribe, initialCall = false }) {
   const { fieldProps, fields, form } = methodArgs;
   const { refs, initialValue } = flushFieldRefs(method, methodArgs);
@@ -81,7 +81,10 @@ export default function makeObservable(method, methodArgs, { observerOptions, su
       });
 
       if (initialCall) {
-        subscription.next({ nextContextProps: fieldProps, shouldValidate });
+        subscription.next({
+          nextContextProps: fieldProps,
+          shouldValidate
+        });
       }
 
       return { refs, initialValue };
@@ -107,7 +110,10 @@ export default function makeObservable(method, methodArgs, { observerOptions, su
           observerOptions
         });
 
-        return subscription.next({ nextContextProps: delegatedFieldProps, shouldValidate });
+        return subscription.next({
+          nextContextProps: delegatedFieldProps,
+          shouldValidate
+        });
       });
   });
 


### PR DESCRIPTION
Implements #182.

## Changelog
* `Form.updateField()` method uses a new interface and accepts an `update` parameter, controlling the update of the field record
* All calls to `updateField()` are rewritten to use the new API
* Reduces the size of the library bundle by ~1 Kb
* No breaking changes, API change is purely internal