### PR TITLE
Introduces "allowMultiple" and "beforeRegister" options for "createField"

### DIFF
--- a/docs/hoc/createField/options.md
+++ b/docs/hoc/createField/options.md
@@ -11,10 +11,17 @@ You don't have to configure any of those options by default. The essential optio
 
 | Option name | Type | Description |
 | ------ | ---- | ----------- |
+| `allowMultiple` | `boolean` | Dictates whether multiple instances of the field with the same name is allowed. |
 | `valuePropName` | `string` | A custom prop name to be treated as an updatable value during the field value change. |
 | `mapPropsToField` | `({ props, context, fieldRecord, valuePropName }) => Object` | A custom maping function which should return a props Object used as the initial props during the field registration. |
 | `enforceProps` | `({ props, contextProps }) => Object` | A function which should return a props Object to be enforced on the custom field. |
+| `beforeRegister` | `({ fieldProps, fields }) => fieldProps` | Applies additional transformations to the `fieldProps`, or prevents from fields registration when returns `false`. |
 | `shouldValidateOnMount` | `({ props, fieldRecord, valuePropName, context }) => boolean` | Controls the necessity of validation upon field mount. |
+
+## `allowMultiple: boolean`
+**Default value:** `false`
+
+By default, field's `name` serves as the unique identifier, preventing the registration of the fields with the same name. However, in some cases (i.e. radio buttons) multiple fields with the same name must be allowed.
 
 ## `valuePropName: string`
 **Default value:** `value`
@@ -91,6 +98,19 @@ export default createField({
   })
 })(Checkbox);
 ```
+
+## `beforeRegister: ({ fieldProps, fields }) => fieldProps`
+**Default value:**
+
+```js
+{
+  beforeRegister({ fieldProps, fields }) {
+    return fieldProps;
+  }
+}
+```
+
+Applies additional transformation or logic to the field right before it is registered. Allows to completely prevent field registration when `false` is returned from this method.
 
 ## `shouldValidateOnMount: ({ props, fieldRecord, valuePropName, context }) => boolean`
 **Default value:**

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -131,7 +131,6 @@ export default class Form extends React.Component {
     const { fields } = this.state;
     const fieldPath = initialFieldProps.get('fieldPath');
     const isAlreadyExist = fields.hasIn(fieldPath);
-    const isRadioButton = (initialFieldProps.get('type') === 'radio');
 
     console.groupCollapsed(fieldPath, '@ registerField');
     console.log('initialFieldProps', initialFieldProps.toJS());
@@ -139,7 +138,7 @@ export default class Form extends React.Component {
     console.groupEnd();
 
     /* Warn on field duplicates */
-    invariant(!(isAlreadyExist && !isRadioButton), 'Cannot register field `%s`, the field with ' +
+    invariant(!(isAlreadyExist && !fieldOptions.allowMultiple), 'Cannot register field `%s`, the field with ' +
       'the provided name is already registered. Make sure the fields on the same level of `Form` ' +
       'or `Field.Group` have unique names.', fieldPath);
 

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -15,6 +15,9 @@ const defaultOptions = {
   mapPropsToField({ fieldRecord }) {
     return fieldRecord;
   },
+  beforeRegister({ fieldProps }) {
+    return fieldProps;
+  },
   shouldValidateOnMount({ fieldRecord, valuePropName }) {
     const fieldValue = fieldRecord[valuePropName];
     return isset(fieldValue) && (fieldValue !== '');
@@ -186,7 +189,10 @@ export default function connectField(options) {
         /* Notify the parent Form that a new field prompts to register */
         form.eventEmitter.emit('fieldRegister', {
           fieldProps,
-          shouldValidateOnMount
+          fieldOptions: {
+            beforeRegister: hocOptions.beforeRegister,
+            shouldValidateOnMount
+          }
         });
 
         return fieldProps;

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -12,6 +12,7 @@ import { isset, camelize, debounce, CustomPropTypes, getComponentName, rxUtils }
 /* Default options for `connectField()` HOC */
 const defaultOptions = {
   valuePropName: 'value',
+  allowMultiple: false,
   mapPropsToField({ fieldRecord }) {
     return fieldRecord;
   },
@@ -142,13 +143,6 @@ export default function connectField(options) {
           valuePropName
         });
 
-        const shouldValidateOnMount = hocOptions.shouldValidateOnMount({
-          fieldRecord,
-          props: this.props,
-          context: this.context,
-          valuePropName
-        });
-
         console.log('fieldRecord:', fieldRecord);
 
         /* Prevent { fieldGroup: undefined } for the fields without a group */
@@ -190,8 +184,14 @@ export default function connectField(options) {
         form.eventEmitter.emit('fieldRegister', {
           fieldProps,
           fieldOptions: {
+            allowMultiple: hocOptions.allowMultiple,
             beforeRegister: hocOptions.beforeRegister,
-            shouldValidateOnMount
+            shouldValidateOnMount: hocOptions.shouldValidateOnMount({
+              fieldRecord,
+              props: this.props,
+              context: this.context,
+              valuePropName
+            })
           }
         });
 

--- a/src/fieldPresets/radio.js
+++ b/src/fieldPresets/radio.js
@@ -1,5 +1,11 @@
 export default {
   /**
+   * There can be multiple radio fields with the same name represented by
+   * a single field record entry in the form's state.
+   */
+  allowMultiple: true,
+
+  /**
    * Handling of contextProps of Radio inputs is unique.
    * 1. Never pass "props.value" to context. <Field.Radio> is always expected to receive a "value" prop,
    * however it should never set it to context on registration. The value in the context will be changed


### PR DESCRIPTION
Implements #233

## Changes
* Adds `beforeRegister` method to `createField` options. This method allows to apply additional transformations to `fieldProps` Map right before the field is registered. It also allows to completely prevent the registration when `false` is returned.
* Adds `allowMultiple` flag to `createField` options. When `true` is returned, form allows to register multiple fields with the same name.