### PR TITLE
RxProps: Use alternative API instead of Proxy

### DIFF
--- a/cypress/integration/validation/SyncValidation/Form.props.rules.spec.jsx
+++ b/cypress/integration/validation/SyncValidation/Form.props.rules.spec.jsx
@@ -10,7 +10,7 @@ describe('Form.props.rules', function () {
       .focus()
       .blur()
       .should('not.have.class', 'is-valid')
-      .should('not.have.class', 'is-invalid');
+      .should('not.have.class', 'is-invalid')
   });
 
   it('clearing optional unexpected field resets validation status', () => {
@@ -19,7 +19,7 @@ describe('Form.props.rules', function () {
       .should('have.class', 'is-invalid')
       .clear()
       .should('not.have.class', 'is-invalid')
-      .should('not.have.class', 'is-valid');
+      .should('not.have.class', 'is-valid')
   });
 
   it('clearing required unexpected field retains validation status', () => {
@@ -30,35 +30,35 @@ describe('Form.props.rules', function () {
       .should('have.class', 'is-invalid')
       .clear()
       .should('have.class', 'is-invalid')
-      .should('not.have.class', 'is-valid');
+      .should('not.have.class', 'is-valid')
   });
 
   it('optional field with name-specific matching value resolves', () => {
     cy.get(fieldSelector)
       .clear().type('some').should('have.value', 'some')
       .should('have.class', 'is-valid')
-      .should('not.have.class', 'is-invalid');
+      .should('not.have.class', 'is-invalid')
   });
 
   it('optional field with name-specific unmatching value rejects', () => {
     cy.get(fieldSelector)
       .clear().type('foo').should('have.value', 'foo')
       .should('have.class', 'is-invalid')
-      .should('not.have.class', 'is-valid');
+      .should('not.have.class', 'is-valid')
   });
 
   it('optional field with type-specific matching value resolves', () => {
     cy.get(fieldSelector)
       .clear().type('some').should('have.value', 'some')
       .should('have.class', 'is-valid')
-      .should('not.have.class', 'is-invalid');
+      .should('not.have.class', 'is-invalid')
   });
 
   it('optional field with type-specific unmatching value rejects', () => {
     cy.get(fieldSelector)
       .clear().type('123').should('have.value', '123')
       .should('have.class', 'is-invalid')
-      .should('not.have.class', 'is-valid');
+      .should('not.have.class', 'is-valid')
   });
 
   it('required field with name-specific matching value resolves', () => {
@@ -67,7 +67,7 @@ describe('Form.props.rules', function () {
     cy.get(fieldSelector)
       .clear().type('some').should('have.value', 'some')
       .should('have.class', 'is-valid')
-      .should('not.have.class', 'is-invalid');
+      .should('not.have.class', 'is-invalid')
   });
 
   it('required field with name-specific unmatching value rejects', () => {
@@ -76,6 +76,19 @@ describe('Form.props.rules', function () {
     cy.get(fieldSelector)
       .clear().type('foo').should('have.value', 'foo')
       .should('have.class', 'is-invalid')
-      .should('not.have.class', 'is-valid');
+      .should('not.have.class', 'is-valid')
   });
+
+  it('re-evaluates rule when referenced field prop updates', () => {
+    cy.get('[name="fieldOne"]')
+      .clear()
+      .type('something').should('have.value', 'something')
+
+    cy.get('[name="fieldTwo"]')
+      .type('foo').should('have.value', 'foo')
+      .should('have.class', 'is-invalid')
+      .clear()
+      .type('something').should('have.value', 'something')
+      .should('have.class', 'is-valid')
+    });
 });

--- a/examples/reactive-props/DelegatedSubscription.jsx
+++ b/examples/reactive-props/DelegatedSubscription.jsx
@@ -14,8 +14,8 @@ export default class RxPropsDelegatedSubscription extends React.Component {
             name="firstName"
             label="Fisrt name"
             hint="Required when `lastName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['lastName', 'value']);
+            required={({ get }) => {
+              return !!get(['lastName', 'value']);
             }} />
           <Input
             name="lastName"

--- a/examples/reactive-props/DelegatedSubscription.jsx
+++ b/examples/reactive-props/DelegatedSubscription.jsx
@@ -14,8 +14,8 @@ export default class RxPropsDelegatedSubscription extends React.Component {
             name="firstName"
             label="Fisrt name"
             hint="Required when `lastName` has value"
-            required={({ fields }) => {
-              return !!fields.lastName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['lastName', 'value']);
             }} />
           <Input
             name="lastName"

--- a/examples/reactive-props/DynamicRequired.jsx
+++ b/examples/reactive-props/DynamicRequired.jsx
@@ -18,8 +18,8 @@ export default class RxPropsDynamicRequired extends React.Component {
             name="lastName"
             label="Last name"
             hint="Required when `firstName` has value"
-            required={({ fields }) => {
-              return !!fields.firstName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['firstName', 'value']);
             }} />
 
           <Button>Submit</Button>

--- a/examples/reactive-props/DynamicRequired.jsx
+++ b/examples/reactive-props/DynamicRequired.jsx
@@ -18,8 +18,8 @@ export default class RxPropsDynamicRequired extends React.Component {
             name="lastName"
             label="Last name"
             hint="Required when `firstName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['firstName', 'value']);
+            required={({ get }) => {
+              return !!get(['firstName', 'value']);
             }} />
 
           <Button>Submit</Button>

--- a/examples/reactive-props/Interdependent.jsx
+++ b/examples/reactive-props/Interdependent.jsx
@@ -14,15 +14,15 @@ export default class RxPropsInterdependent extends React.Component {
             name="firstName"
             label="First name"
             hint="Required when `lastName` has value"
-            required={({ fields }) => {
-              return !!fields.lastName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['lastName', 'value']);
             }} />
           <Input
             name="lastName"
             label="Last name"
             hint="Required when `firstName` has value"
-            required={({ fields }) => {
-              return !!fields.firstName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['firstName', 'value']);
             }} />
 
           <Button>Submit</Button>

--- a/examples/reactive-props/Interdependent.jsx
+++ b/examples/reactive-props/Interdependent.jsx
@@ -14,15 +14,15 @@ export default class RxPropsInterdependent extends React.Component {
             name="firstName"
             label="First name"
             hint="Required when `lastName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['lastName', 'value']);
+            required={({ get }) => {
+              return !!get(['lastName', 'value']);
             }} />
           <Input
             name="lastName"
             label="Last name"
             hint="Required when `firstName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['firstName', 'value']);
+            required={({ get }) => {
+              return !!get(['firstName', 'value']);
             }} />
 
           <Button>Submit</Button>

--- a/examples/reactive-props/SingleTarget.jsx
+++ b/examples/reactive-props/SingleTarget.jsx
@@ -14,8 +14,8 @@ export default class RxPropsSingleTarget extends React.Component {
             name="firstName"
             label="First name"
             hint="Required when `lastName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['lastName', 'value']);
+            required={({ get }) => {
+              return !!get(['lastName', 'value']);
             }} />
           <Input
             name="lastName"
@@ -24,8 +24,8 @@ export default class RxPropsSingleTarget extends React.Component {
             name="fieldThree"
             label="Some field three"
             hint="Required when `lastName` has value"
-            required={({ getFieldProp }) => {
-              return !!getFieldProp(['lastName', 'value'])
+            required={({ get }) => {
+              return !!get(['lastName', 'value'])
             }} />
           <Button>Submit</Button>
         </Form>

--- a/examples/reactive-props/SingleTarget.jsx
+++ b/examples/reactive-props/SingleTarget.jsx
@@ -14,8 +14,8 @@ export default class RxPropsSingleTarget extends React.Component {
             name="firstName"
             label="First name"
             hint="Required when `lastName` has value"
-            required={({ fields }) => {
-              return !!fields.lastName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['lastName', 'value']);
             }} />
           <Input
             name="lastName"
@@ -24,8 +24,8 @@ export default class RxPropsSingleTarget extends React.Component {
             name="fieldThree"
             label="Some field three"
             hint="Required when `lastName` has value"
-            required={({ fields }) => {
-              return !!fields.lastName.value;
+            required={({ getFieldProp }) => {
+              return !!getFieldProp(['lastName', 'value'])
             }} />
           <Button>Submit</Button>
         </Form>

--- a/examples/validation/SyncValidation/Form.props.rules.jsx
+++ b/examples/validation/SyncValidation/Form.props.rules.jsx
@@ -12,6 +12,9 @@ const rules = {
     fieldOne: ({ value, fieldProps }) => {
       const { ref: { props } } = fieldProps;
       return (value !== 'foo');
+    },
+    fieldTwo: ({ value, getFieldProp }) => {
+      return (value === getFieldProp(['fieldOne', 'value']));
     }
   }
 };
@@ -25,6 +28,10 @@ export default class FormPropsRules extends React.Component {
           name="fieldOne"
           label="Field one"
           hint="Must be more than 3 characters and not equal to `foo`" />
+        <Input
+          name="fieldTwo"
+          label="Field two"
+          hint="Valid when equals to `fieldOne` value" />
       </Form>
     );
   }

--- a/examples/validation/SyncValidation/Form.props.rules.jsx
+++ b/examples/validation/SyncValidation/Form.props.rules.jsx
@@ -13,8 +13,8 @@ const rules = {
       const { ref: { props } } = fieldProps;
       return (value !== 'foo');
     },
-    fieldTwo: ({ value, getFieldProp }) => {
-      return (value === getFieldProp(['fieldOne', 'value']));
+    fieldTwo: ({ value, get }) => {
+      return (value === get(['fieldOne', 'value']));
     }
   }
 };

--- a/src/utils/fieldUtils/createPropGetter.js
+++ b/src/utils/fieldUtils/createPropGetter.js
@@ -1,12 +1,17 @@
 /**
- * Generates a field prop getter function.
+ * A thunk to generate a field prop getter function.
  * The latter is used for reactive props implementation and allows to flush
  * field prop references into a single source using a callback function.
  * @param {Map} fields
  * @param {Function} callback
+ * @returns {Function} A field prop getter function.
  */
 export default function createPropGetter(fields, callback) {
   return (propPath) => {
+    /**
+     * Getting the value is an internal procedure operating with Immutable fields.
+     * This logic is not affected by the "withImmutable" option.
+     */
     const propValue = fields.getIn(propPath);
 
     if (callback) {

--- a/src/utils/fieldUtils/createPropGetter.js
+++ b/src/utils/fieldUtils/createPropGetter.js
@@ -1,0 +1,18 @@
+/**
+ * Generates a field prop getter function.
+ * The latter is used for reactive props implementation and allows to flush
+ * field prop references into a single source using a callback function.
+ * @param {Map} fields
+ * @param {Function} callback
+ */
+export default function createPropGetter(fields, callback) {
+  return (propPath) => {
+    const propValue = fields.getIn(propPath);
+
+    if (callback) {
+      callback(propPath, propValue);
+    }
+
+    return propValue;
+  };
+}

--- a/src/utils/fieldUtils/index.js
+++ b/src/utils/fieldUtils/index.js
@@ -10,3 +10,4 @@ export getErrorMessages from './getErrorMessages';
 
 /* Other */
 export serializeFields from './serializeFields';
+export createPropGetter from './createPropGetter';

--- a/src/utils/fieldUtils/validateSync.js
+++ b/src/utils/fieldUtils/validateSync.js
@@ -90,7 +90,7 @@ export default function validateSync({ fieldProps, fields, form }) {
   const resolverArgs = {
     [valuePropName]: value,
     fieldProps,
-    getFieldProp: createPropGetter(fields),
+    get: createPropGetter(fields),
     fields,
     form
   };

--- a/src/utils/flushFieldRefs.js
+++ b/src/utils/flushFieldRefs.js
@@ -10,11 +10,11 @@ import createPropGetter from './fieldUtils/createPropGetter';
 export default function flushFieldRefs(method, methodArgs) {
   const { fields, form } = methodArgs;
   const refs = [];
-  const getFieldProp = createPropGetter(fields, propPath => refs.push(propPath));
+  const fieldPropGetter = createPropGetter(fields, propRefPath => refs.push(propRefPath));
 
   const initialValue = dispatch(method, {
     ...methodArgs,
-    getFieldProp
+    get: fieldPropGetter
   }, form.context);
 
   return { refs, initialValue };

--- a/src/utils/rxUtils/createRulesSubscriptions.js
+++ b/src/utils/rxUtils/createRulesSubscriptions.js
@@ -2,11 +2,12 @@ import makeObservable from './makeObservable';
 import flushFieldRefs from '../flushFieldRefs';
 import getFieldRules from '../formUtils/getFieldRules';
 
-//
-// TODO
-// Change rule subscriptions according to new "getFieldProp" API
-//
-
+/**
+ * Creates an observable for each validation rule which referenced other fields' props.
+ * @param {Map} fieldProps
+ * @param {Map} fields
+ * @param {Object} form
+ */
 export default function createRulesSubscriptions({ fieldProps, fields, form }) {
   const { rxRules } = form.state;
   const value = fieldProps.get(fieldProps.get('valuePropName'));

--- a/src/utils/rxUtils/createRulesSubscriptions.js
+++ b/src/utils/rxUtils/createRulesSubscriptions.js
@@ -2,17 +2,30 @@ import makeObservable from './makeObservable';
 import flushFieldRefs from '../flushFieldRefs';
 import getFieldRules from '../formUtils/getFieldRules';
 
+//
+// TODO
+// Change rule subscriptions according to new "getFieldProp" API
+//
+
 export default function createRulesSubscriptions({ fieldProps, fields, form }) {
   const { rxRules } = form.state;
   const value = fieldProps.get(fieldProps.get('valuePropName'));
-  const resolverArgs = { value, fieldProps, fields, form };
+
+  const resolverArgs = {
+    value,
+    fieldProps,
+    fields,
+    form
+  };
 
   const ruleGroups = getFieldRules({
     fieldProps,
     schema: form.formRules,
-    transformRule(defaultProps) {
-      const { refs } = flushFieldRefs(defaultProps.resolver, resolverArgs);
-      return { ...defaultProps, refs };
+    transformRule(ruleParams) {
+      return {
+        ...ruleParams,
+        refs: flushFieldRefs(ruleParams.resolver, resolverArgs)
+      };
     }
   });
 
@@ -21,7 +34,9 @@ export default function createRulesSubscriptions({ fieldProps, fields, form }) {
   }
 
   /**
-   * Create observable for each rule resolver function to watch for the referenced fields.
+   * Create observable for each rule where another field(s) is referenced.
+   * The observable will listen for the referenced props change event and re-evaluate
+   * the validation rule(s) where that prop is referenced.
    */
   ruleGroups.forEach((ruleGroup) => {
     ruleGroup.forEach((rule) => {
@@ -31,7 +46,10 @@ export default function createRulesSubscriptions({ fieldProps, fields, form }) {
 
       makeObservable(rule.resolver, resolverArgs, {
         subscribe() {
-          form.eventEmitter.emit('validateField', { fieldProps, force: true });
+          form.eventEmitter.emit('validateField', {
+            fieldProps,
+            force: true
+          });
         }
       });
     });

--- a/src/utils/rxUtils/createSubscriptions.js
+++ b/src/utils/rxUtils/createSubscriptions.js
@@ -23,7 +23,7 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
         const nextPropValue = resolver({
           fieldProps: fieldProps.toJS(),
           fields: nextFields.toJS(),
-          getFieldProp: createPropGetter(nextFields),
+          get: createPropGetter(nextFields),
           form
         }, form.context);
 

--- a/src/utils/rxUtils/createSubscriptions.js
+++ b/src/utils/rxUtils/createSubscriptions.js
@@ -1,5 +1,5 @@
 import makeObservable from './makeObservable';
-import ensafeMap from '../ensafeMap';
+import createPropGetter from '../fieldUtils/createPropGetter';
 
 /**
  * @param {Map} fieldProps
@@ -14,16 +14,16 @@ export default function createSubscriptions({ fieldProps, fields, form }) {
   const resolverArgs = { fieldProps, fields, form };
 
   rxProps.forEach((resolver, rxPropName) => {
-    const { refs } = makeObservable(resolver, resolverArgs, {
+    makeObservable(resolver, resolverArgs, {
       initialCall: true,
       subscribe({ nextContextProps, shouldValidate = true }) {
         const refFieldPath = nextContextProps.get('fieldPath');
         const nextFields = form.state.fields.set(refFieldPath, nextContextProps);
-        const safeFields = ensafeMap(nextFields, refs);
 
         const nextPropValue = resolver({
           fieldProps: fieldProps.toJS(),
-          fields: safeFields.toJS(),
+          fields: nextFields.toJS(),
+          getFieldProp: createPropGetter(nextFields),
           form
         }, form.context);
 

--- a/test/unit/utils/flushFieldRefs.spec.js
+++ b/test/unit/utils/flushFieldRefs.spec.js
@@ -6,14 +6,14 @@ import { flushFieldRefs, fieldUtils } from '../../../src/utils';
 describe('flushFieldRefs', function () {
   it('Flushes referenced field paths properly', () => {
     const fields = fromJS({ fieldOne: { value: 'foo' } });
-    const method = ({ getFieldProp }) => {
-      getFieldProp(['fieldOne', 'value']);
-      getFieldProp(['groupOne', 'fieldOne', 'required']);
+    const method = ({ get }) => {
+      get(['fieldOne', 'value']);
+      get(['groupOne', 'fieldOne', 'required']);
     };
 
-    const getFieldProp = fieldUtils.createPropGetter(fields);
+    const fieldPropGetter = fieldUtils.createPropGetter(fields);
     const { refs } = flushFieldRefs(method, {
-      getFieldProp,
+      get: fieldPropGetter,
       fields,
       form
     });
@@ -25,9 +25,9 @@ describe('flushFieldRefs', function () {
 
   it('Resolves initial value properly', () => {
     const fields = fromJS({ fieldOne: { value: 'foo' } });
-    const method = ({ getFieldProp }) => {
-      getFieldProp(['nonExisting', 'fieldPath', 'propName']);
-      return getFieldProp(['fieldOne', 'value']);
+    const method = ({ get }) => {
+      get(['nonExisting', 'fieldPath', 'propName']);
+      return get(['fieldOne', 'value']);
     };
 
     const { initialValue } = flushFieldRefs(method, { fields, form });

--- a/test/unit/utils/flushFieldRefs.spec.js
+++ b/test/unit/utils/flushFieldRefs.spec.js
@@ -1,17 +1,22 @@
 import { fromJS } from 'immutable';
 import { expect } from 'chai';
 import { form } from '../../utils';
-import { flushFieldRefs } from '../../../src/utils';
+import { flushFieldRefs, fieldUtils } from '../../../src/utils';
 
 describe('flushFieldRefs', function () {
   it('Flushes referenced field paths properly', () => {
     const fields = fromJS({ fieldOne: { value: 'foo' } });
-    const method = ({ fields }) => {
-      fields.fieldOne.value;
-      fields.groupOne.fieldOne.required;
+    const method = ({ getFieldProp }) => {
+      getFieldProp(['fieldOne', 'value']);
+      getFieldProp(['groupOne', 'fieldOne', 'required']);
     };
 
-    const { refs } = flushFieldRefs(method, { fields, form });
+    const getFieldProp = fieldUtils.createPropGetter(fields);
+    const { refs } = flushFieldRefs(method, {
+      getFieldProp,
+      fields,
+      form
+    });
 
     expect(refs).to.be.an.instanceof(Array).with.lengthOf(2);
     expect(refs[0]).to.deep.equal(['fieldOne', 'value']);
@@ -20,9 +25,9 @@ describe('flushFieldRefs', function () {
 
   it('Resolves initial value properly', () => {
     const fields = fromJS({ fieldOne: { value: 'foo' } });
-    const method = ({ fields }) => {
-      fields.nonExisting.fieldPath.propName;
-      return fields.fieldOne.value;
+    const method = ({ getFieldProp }) => {
+      getFieldProp(['nonExisting', 'fieldPath', 'propName']);
+      return getFieldProp(['fieldOne', 'value']);
     };
 
     const { initialValue } = flushFieldRefs(method, { fields, form });


### PR DESCRIPTION
Implements #243.

## Changelog
* Removes the usage of `Proxy` completely
* Rewords the API for reactive props, as the consequence
* Introduces explicit helper method to subscribe/get field props in `required` prop and sync rule resolver functions