### PR TITLE
Adds "Form.clear" for clearing the fields

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -606,14 +606,27 @@ export default class Form extends React.Component {
   }
 
   /**
+   * Clears all the fields.
+   */
+  clear = () => {
+    const nextFields = this.state.fields.map(fieldUtils.resetField(() => ''));
+    this.setState({ fields: nextFields });
+  }
+
+  /**
    * Resets all the fields to their initial state upon mounting.
    */
   reset = () => {
-    const nextFields = this.state.fields.map(fieldProps => fieldUtils.resetField(fieldProps));
+    const nextFields = this.state.fields.map(fieldUtils.resetField((fieldProps) => {
+      return fieldProps.get('initialValue');
+    }));
 
     this.setState({ fields: nextFields }, () => {
-      /* Validate only non-empty fields, since empty required fields should not be unexpected on reset */
-      this.validate(entry => Map.isMap(entry) && (entry.get('value') !== ''));
+      /**
+       * Validate only non-empty fields, since empty required fields should
+       * not be unexpected upon reset.
+       */
+      this.validate(fieldProps => Map.isMap(fieldProps) && (fieldProps.get('value') !== ''));
 
       /* Call custom callback methods to be able to reset controlled fields */
       const { onReset } = this.props;

--- a/src/utils/fieldUtils/resetField.js
+++ b/src/utils/fieldUtils/resetField.js
@@ -3,21 +3,26 @@
  * @param {Map} fieldProps
  * @returns {Map}
  */
-export default function resetField(fieldProps) {
-  /* Get the dynamic property name which represents the field's value (i.e. "checked" for Checkbox) */
-  const valuePropName = fieldProps.get('valuePropName');
-  const initialValue = fieldProps.get('initialValue');
+export default function resetField(getNextValue) {
+  return (fieldProps) => {
+    /**
+     * Get the dynamic property name which represents the
+     * field's value (i.e. "checked" for Checkbox).
+     */
+    const valuePropName = fieldProps.get('valuePropName');
+    const nextValue = getNextValue(fieldProps);
 
-  return fieldProps.merge({
-    [valuePropName]: initialValue,
-    expected: true,
-    valid: false,
-    invalid: false,
-    validating: false,
-    validated: false,
-    validSync: false,
-    validAsync: false,
-    validatedSync: false,
-    validatedAsync: false
-  });
+    return fieldProps.merge({
+      [valuePropName]: nextValue,
+      expected: true,
+      valid: false,
+      invalid: false,
+      validating: false,
+      validated: false,
+      validSync: false,
+      validAsync: false,
+      validatedSync: false,
+      validatedAsync: false
+    });
+  };
 }


### PR DESCRIPTION
* Fixes #265 

## Changelog
* Adds new `clear` method to the Form class
* Extends `fieldUtils.resetField` function to be a HoF, accepting `getNextValue` function as an argument, and returning an applicator function expecting a `fieldProps` instance.