### PR TITLE
Accepts "initialValues" prop for "Form" component

### DIFF
--- a/cypress/integration/basics/InitialValues.spec.jsx
+++ b/cypress/integration/basics/InitialValues.spec.jsx
@@ -6,6 +6,9 @@ describe('Initial values', function() {
   const initialValues = {
     firstName: 'Kate',
     username: 'admin',
+    billingAddress: {
+      street: 'Baker st.',
+    },
   }
 
   before(() => {
@@ -14,12 +17,18 @@ describe('Initial values', function() {
 
   it('Takes "fieldProps.initialValue" as the highest priority', () => {
     cy.getField('firstName').should('have.value', 'John')
+    cy.getField('houseNumber').should('have.value', '4')
   })
 
-  it('Takes "Form.props.initialValues" the highest priority source of initial value', () => {
+  it('Takes "Form.props.initialValues"', () => {
     cy.getField('username')
       .should('have.value', initialValues.username)
       .valid()
+
+    cy.getField('street').should(
+      'have.value',
+      initialValues.billingAddress.street,
+    )
   })
 
   it('Takes field-wide "initialValue" as the last fallback, when such value is set', () => {

--- a/cypress/integration/basics/InitialValues.spec.jsx
+++ b/cypress/integration/basics/InitialValues.spec.jsx
@@ -9,6 +9,9 @@ describe('Initial values', function() {
     billingAddress: {
       street: 'Baker st.',
     },
+    deliveryAddress: {
+      street: 'Sunwell ave.',
+    },
   }
 
   before(() => {
@@ -25,9 +28,14 @@ describe('Initial values', function() {
       .should('have.value', initialValues.username)
       .valid()
 
-    cy.getField('street').should(
+    cy.get('#billing-street').should(
       'have.value',
       initialValues.billingAddress.street,
+    )
+
+    cy.get('#delivery-street').should(
+      'have.value',
+      initialValues.deliveryAddress.street,
     )
   })
 

--- a/cypress/integration/basics/InitialValues.spec.jsx
+++ b/cypress/integration/basics/InitialValues.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { expect } from 'chai'
+import Scenario from '@examples/basics/InitialValues'
+
+describe('Initial values', function() {
+  const initialValues = {
+    firstName: 'Kate',
+    username: 'admin',
+  }
+
+  before(() => {
+    cy.loadStory(<Scenario initialValues={initialValues} />)
+  })
+
+  it('Takes "fieldProps.initialValue" as the highest priority', () => {
+    cy.getField('firstName').should('have.value', 'John')
+  })
+
+  it('Takes "Form.props.initialValues" the highest priority source of initial value', () => {
+    cy.getField('username')
+      .should('have.value', initialValues.username)
+      .valid()
+  })
+
+  it('Takes field-wide "initialValue" as the last fallback, when such value is set', () => {
+    cy.getField('occupation').should('have.value', 'developer')
+  })
+})

--- a/cypress/integration/basics/index.js
+++ b/cypress/integration/basics/index.js
@@ -1,5 +1,6 @@
 describe('Basics', function() {
   require('./Interactions.controlled')
   require('./Interactions.uncontrolled')
+  require('./InitialValues')
   require('./Submit')
 })

--- a/examples/basics/InitialValues.jsx
+++ b/examples/basics/InitialValues.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fieldPresets, createField, Form } from '@lib'
+import { fieldPresets, createField, Form, Field } from '@lib'
 import { Input } from '@fields'
 import { Select } from '@examples/fields/Select'
 import Button from '@shared/Button'
@@ -23,6 +23,11 @@ export default class InitialValues extends React.Component {
             <option value="developer">Developer</option>
             <option value="designer">Designer</option>
           </OccupattionSelect>
+
+          <Field.Group name="billingAddress">
+            <Input name="street" label="Street" />
+            <Input name="houseNumber" label="Street" initialValue="4" />
+          </Field.Group>
         </Form>
       </React.Fragment>
     )

--- a/examples/basics/InitialValues.jsx
+++ b/examples/basics/InitialValues.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { fieldPresets, createField, Form } from '@lib'
+import { Input } from '@fields'
+import { Select } from '@examples/fields/Select'
+import Button from '@shared/Button'
+
+const OccupattionSelect = createField({
+  ...fieldPresets.select,
+  initialValue: 'developer',
+})(Select)
+
+export default class InitialValues extends React.Component {
+  render() {
+    return (
+      <React.Fragment>
+        <h1>Initial values</h1>
+        <Form {...this.props}>
+          <Input name="firstName" label="First name" initialValue="John" />
+          <Input name="username" label="Username" required />
+
+          <OccupattionSelect name="occupation">
+            <option value="doctor">Doctor</option>
+            <option value="developer">Developer</option>
+            <option value="designer">Designer</option>
+          </OccupattionSelect>
+        </Form>
+      </React.Fragment>
+    )
+  }
+}

--- a/examples/basics/InitialValues.jsx
+++ b/examples/basics/InitialValues.jsx
@@ -25,8 +25,16 @@ export default class InitialValues extends React.Component {
           </OccupattionSelect>
 
           <Field.Group name="billingAddress">
-            <Input name="street" label="Street" />
+            <Input id="billing-street" name="street" label="Street (billing)" />
             <Input name="houseNumber" label="Street" initialValue="4" />
+          </Field.Group>
+
+          <Field.Group name="deliveryAddress">
+            <Input
+              id="delivery-street"
+              name="street"
+              label="Street (delivery)"
+            />
           </Field.Group>
         </Form>
       </React.Fragment>

--- a/examples/fields/Select.jsx
+++ b/examples/fields/Select.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { createField, fieldPresets } from '../../'
 
-class Select extends React.Component {
+export class Select extends React.Component {
   static propTypes = {
     /* General */
     id: PropTypes.string,

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -50,6 +50,7 @@ export default class Form extends React.Component {
     /* General */
     innerRef: PropTypes.func,
     action: PropTypes.func.isRequired,
+    initialValues: PropTypes.object,
 
     /* Validation */
     rules: ValidationRulesPropType,
@@ -67,6 +68,7 @@ export default class Form extends React.Component {
 
   static defaultProps = {
     action: () => new Promise((resolve) => resolve()),
+    initialValues: {},
   }
 
   state = {
@@ -98,8 +100,15 @@ export default class Form extends React.Component {
 
   constructor(props, context) {
     super(props, context)
-    const { rules: explicitRules, messages: explicitMessages } = props
+    const {
+      initialValues,
+      rules: explicitRules,
+      messages: explicitMessages,
+    } = props
     const { debounceTime, rules, messages } = context
+
+    /* Convert initial values to immutable Map for deep field references */
+    this.initialValues = initialValues && fromJS(initialValues)
 
     /* Set the validation debounce duration */
     this.debounceTime = isset(debounceTime) ? debounceTime : defaultDebounceTime

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -68,7 +68,6 @@ export default class Form extends React.Component {
 
   static defaultProps = {
     action: () => new Promise((resolve) => resolve()),
-    initialValues: {},
   }
 
   state = {
@@ -100,15 +99,8 @@ export default class Form extends React.Component {
 
   constructor(props, context) {
     super(props, context)
-    const {
-      initialValues,
-      rules: explicitRules,
-      messages: explicitMessages,
-    } = props
+    const { rules: explicitRules, messages: explicitMessages } = props
     const { debounceTime, rules, messages } = context
-
-    /* Convert initial values to immutable Map for deep field references */
-    this.initialValues = initialValues && fromJS(initialValues)
 
     /* Set the validation debounce duration */
     this.debounceTime = isset(debounceTime) ? debounceTime : defaultDebounceTime

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -3,6 +3,7 @@
  * component. Used for custom field styling, implementing fields with custom logic, and
  * third-party field components integration.
  */
+import path from 'ramda/src/path'
 import React from 'react'
 import PropTypes from 'prop-types'
 import hoistNonReactStatics from 'hoist-non-react-statics'
@@ -39,10 +40,19 @@ const defaultOptions = {
   },
 }
 
+/**
+ * Returns the initial value for the given fields.
+ * Takes field props, initial values of a form and field's class into account.
+ * @param {string[]} fieldPath
+ * @param {Record} fieldProps
+ * @param {Map} initialValues
+ * @param {Object} hocOptions
+ * @returns {string?}
+ */
 const getInitialValue = (fieldPath, fieldProps, initialValues, hocOptions) => {
   return (
     fieldProps.initialValue ||
-    (initialValues && initialValues.getIn(fieldPath)) ||
+    (initialValues && path(fieldPath, initialValues)) ||
     hocOptions.initialValue
   )
 }
@@ -101,7 +111,7 @@ export default function connectField(options) {
         const initialValue = getInitialValue(
           fieldPath,
           directProps,
-          form.initialValues,
+          form.props.initialValues,
           hocOptions,
         )
         const registeredValue = isset(contextValue)


### PR DESCRIPTION
* Fixes #262 

## Changes log
* Adds `initialValues: PropTypes.object` prop to the `Form` component
* Adjusts the logic to determine field's initial value upon its registration in `createField`
* Uses the following fallback map to get a field's initial value:
  * `fieldProps.initialValue`
  * `form.props.initialValues[fieldPath]`
  * `fieldHocOptions.initialValue`
* Provides integration tests to cover the introduced changes