### PR TITLE
Adds "onSerialize" form prop. Replaces ImmutableJS with Ramda.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "useTabs": false,
   "semi": false,
   "tabWidth": 2,
-  "jsxBracketSameLine": false
+  "jsxBracketSameLine": false,
+  "printWidth": 100
 }

--- a/cypress/integration/basics/InitialValues.spec.jsx
+++ b/cypress/integration/basics/InitialValues.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { expect } from 'chai'
 import Scenario from '@examples/basics/InitialValues'
 
 describe('Initial values', function() {

--- a/cypress/integration/components/createField.spec.jsx
+++ b/cypress/integration/components/createField.spec.jsx
@@ -1,3 +1,4 @@
+import * as R from 'ramda'
 import React from 'react'
 import { Record } from 'immutable'
 import { expect } from 'chai'
@@ -12,7 +13,7 @@ describe('createField', function() {
     cy.get('[name="fieldOne"]').then(() => {
       setTimeout(() => {
         const { fields } = this.form.state
-        const fieldProps = fields.get('fieldOne')
+        const fieldProps = R.path(['fieldOne'], fields)
 
         expect(Record.isRecord(fieldProps))
         expect(fieldProps.name).to.equal('fieldOne')
@@ -24,8 +25,7 @@ describe('createField', function() {
   it('Supports custom field event handlers', () => {
     const testWord = 'Text'
 
-    cy
-      .get('[name="fieldOne"]')
+    cy.get('[name="fieldOne"]')
       .type(testWord)
       .should('have.value', testWord)
     cy.get('#count').should('have.text', String(testWord.length))

--- a/cypress/integration/field-grouping/NestedGroups.spec.jsx
+++ b/cypress/integration/field-grouping/NestedGroups.spec.jsx
@@ -1,5 +1,5 @@
+import * as R from 'ramda'
 import React from 'react'
-import { expect } from 'chai'
 import Scenario from '@examples/field-grouping/NestedGroups'
 
 describe('Nested groups', function() {
@@ -11,10 +11,10 @@ describe('Nested groups', function() {
     await cy.wait(100)
     const { fields } = this.form.state
 
-    expect(fields.has('fieldOne')).to.be.true
-    expect(fields.hasIn(['groupName', 'fieldOne'])).to.be.true
-    expect(fields.hasIn(['groupName', 'fieldTwo'])).to.be.true
-    expect(fields.hasIn(['groupName', 'nestedGroup', 'fieldOne'])).to.be.true
+    expect(R.has('fieldOne', fields))
+    expect(R.path(['groupName', 'fieldOne'], fields)).not.to.be.undefined
+    expect(R.path(['groupName', 'fieldTwo'], fields)).not.to.be.undefined
+    expect(R.path(['groupName', 'nestedGroup', 'fieldOne'])).not.to.be.undefined
   })
 
   it('Serializes nested field groups properly', () => {

--- a/cypress/integration/field-grouping/SimpleGroup.spec.jsx
+++ b/cypress/integration/field-grouping/SimpleGroup.spec.jsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import * as R from 'ramda'
 import { expect } from 'chai'
+import React from 'react'
 import Scenario from '@examples/field-grouping/SimpleGroup'
 
 describe('Simple group', function() {
@@ -11,9 +12,9 @@ describe('Simple group', function() {
     await cy.wait(100)
     const { fields } = this.form.state
 
-    expect(fields.has('fieldOne')).to.be.true
-    expect(fields.hasIn(['groupName', 'fieldOne'])).to.be.true
-    expect(fields.hasIn(['groupName', 'fieldTwo'])).to.be.true
+    expect(R.has('fieldOne', fields))
+    expect(R.path(['groupName', 'fieldOne'], fields)).not.to.be.undefined
+    expect(R.path(['groupName', 'fieldTwo'], fields)).not.to.be.undefined
   })
 
   it('Serializes grouped fields properly', () => {

--- a/cypress/integration/field-grouping/SplitGroups.spec.jsx
+++ b/cypress/integration/field-grouping/SplitGroups.spec.jsx
@@ -1,3 +1,4 @@
+import * as R from 'ramda'
 import React from 'react'
 import { expect } from 'chai'
 import Scenario from '@examples/field-grouping/SplitGroups'
@@ -11,21 +12,18 @@ describe('Split groups', function() {
     await cy.wait(100)
     const { fields } = this.form.state
 
-    expect(fields.has('email')).to.be.true
-    expect(fields.has('password')).to.be.true
-    expect(fields.hasIn(['primaryInfo', 'firstName'])).to.be.true
-    expect(fields.hasIn(['primaryInfo', 'lastName'])).to.be.true
-    expect(fields.hasIn(['primaryInfo', 'newsletter'])).to.be.true
-    expect(fields.hasIn(['primaryInfo', 'billingAddress', 'street'])).to.be.true
-    expect(fields.hasIn(['primaryInfo', 'billingAddress', 'houseNumber'])).to.be
-      .true
-    expect(fields.hasIn(['billingAddress', 'noCollision'])).to.be.true
+    expect(R.has('email', fields)).to.be.true
+    expect(R.has('password', fields)).to.be.true
+    expect(R.path(['primaryInfo', 'firstName'], fields)).to.not.be.undefined
+    expect(R.path(['primaryInfo', 'lastName'], fields)).to.not.be.undefined
+    expect(R.path(['primaryInfo', 'newsletter'], fields)).to.not.be.undefined
+    expect(R.path(['primaryInfo', 'billingAddress', 'street'], fields)).to.not.be.undefined
+    expect(R.path(['primaryInfo', 'billingAddress', 'houseNumber'], fields)).to.not.be.undefined
+    expect(R.path(['billingAddress', 'noCollision'], fields)).to.not.be.undefined
   })
 
   it('Serializes split field groups properly', () => {
     const serialized = this.form.serialize()
-
-    console.log(JSON.stringify(serialized))
 
     expect(serialized).to.deep.equal({
       email: 'john@maverick.com',

--- a/src/components/FormProvider.jsx
+++ b/src/components/FormProvider.jsx
@@ -45,7 +45,7 @@ export default class FormProvider extends React.Component {
     const { rules, messages, withImmutable, debounceTime } = this.props
 
     return {
-      rules: fromJS(rules),
+      rules,
       messages: fromJS(messages),
       withImmutable,
       debounceTime,

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -4,6 +4,7 @@
  * third-party field components integration.
  */
 import path from 'ramda/src/path'
+
 import React from 'react'
 import PropTypes from 'prop-types'
 import hoistNonReactStatics from 'hoist-non-react-statics'
@@ -11,7 +12,6 @@ import {
   isset,
   camelize,
   debounce,
-  CustomPropTypes,
   getComponentName,
   recordUtils,
   rxUtils,
@@ -77,7 +77,7 @@ export default function connectField(options) {
 
       static contextTypes = {
         form: PropTypes.object.isRequired,
-        fields: CustomPropTypes.Map.isRequired,
+        fields: PropTypes.object.isRequired,
         fieldGroup: PropTypes.arrayOf(PropTypes.string),
       }
 
@@ -103,7 +103,7 @@ export default function connectField(options) {
         const { props: directProps, context, fieldPath } = this
         const { fields, fieldGroup, form } = context
         const value = directProps[valuePropName]
-        const contextValue = fields.getIn([...fieldPath, valuePropName])
+        const contextValue = path(fieldPath.concat(valuePropName), fields)
 
         const { reactiveProps, prunedProps } = rxUtils.getRxProps(directProps)
 
@@ -121,6 +121,7 @@ export default function connectField(options) {
         const initialFieldProps = {
           ref: this,
           fieldGroup,
+          fieldPath,
           name: prunedProps.name,
           type: prunedProps.type,
           valuePropName,
@@ -223,7 +224,7 @@ export default function connectField(options) {
        */
       componentWillUpdate(nextProps, nextState, nextContext) {
         /* Bypass scenarios when field is being updated, but not yet registred within the Form */
-        const nextContextProps = nextContext.fields.getIn(this.fieldPath)
+        const nextContextProps = path(this.fieldPath, nextContext.fields)
 
         if (!nextContextProps) {
           return

--- a/src/fieldPresets/radio.js
+++ b/src/fieldPresets/radio.js
@@ -1,3 +1,5 @@
+import path from 'ramda/src/path'
+
 export default {
   /**
    * There can be multiple radio fields with the same name represented by
@@ -14,7 +16,7 @@ export default {
    * 2. Determine "initialValue" based on optional "checked" prop.
    * 3. Add new "checked" props unique to this field type.
    */
-  mapPropsToField({ fieldRecord, props: { checked, value, onChange } }) {
+  mapPropsToField: ({ fieldRecord, props: { checked, value, onChange } }) => {
     fieldRecord.type = 'radio'
     fieldRecord.controlled = !!onChange
 
@@ -35,16 +37,16 @@ export default {
    * propagate their value to the field's record, other radio fields are
    * registered, but their value is ignored.
    */
-  beforeRegister({ fieldProps, fields }) {
+  beforeRegister: ({ fieldProps, fields }) => {
     const { fieldPath } = fieldProps
-    const alreadyExist = fields.hasIn(fieldPath)
+    const alreadyExist = path(fieldPath, fields)
 
     if (!alreadyExist) {
       return fieldProps
     }
 
     const valuePropName = fieldProps.get('valuePropName')
-    const existingValue = fields.getIn([...fieldPath, valuePropName])
+    const existingValue = path(fieldPath.concat(valuePropName), fields)
 
     if (existingValue) {
       return false
@@ -66,7 +68,7 @@ export default {
    * value, but a "checked" prop. Regardless, what should be compared is the
    * next value and the current value in the field's record.
    */
-  shouldUpdateRecord({ nextValue, nextProps, contextProps }) {
+  shouldUpdateRecord: ({ nextValue, nextProps, contextProps }) => {
     return nextProps.checked && nextValue !== contextProps.get('value')
   },
 

--- a/src/utils/fieldUtils/createPropGetter.js
+++ b/src/utils/fieldUtils/createPropGetter.js
@@ -1,3 +1,5 @@
+import path from 'ramda/src/path'
+
 /**
  * A thunk to generate a field prop getter function.
  * The latter is used for reactive props implementation and allows to flush
@@ -12,7 +14,7 @@ export default function createPropGetter(fields, callback) {
      * Internally, "fields" are always Immutable Map and are not affected
      * by the form context options.
      */
-    const propValue = fields.getIn(propPath)
+    const propValue = path(propPath, fields)
 
     if (callback) {
       callback(propPath, propValue)

--- a/src/utils/fieldUtils/serializeFields.js
+++ b/src/utils/fieldUtils/serializeFields.js
@@ -1,14 +1,17 @@
-import { Record } from 'immutable'
 import flattenDeep from '../flattenDeep'
 import * as recordUtils from '../recordUtils'
 
-function predicate(fieldProps) {
-  if (!Record.isRecord(fieldProps) || !fieldProps.fieldPath) {
+const predicate = (fieldProps) => {
+  console.log('   serialize: predicate')
+  console.log('   fieldProps:', fieldProps)
+
+  if (!fieldProps.fieldPath) {
     return
   }
 
   /* Bypass the fields which should be skipped */
   if (fieldProps.skip) {
+    console.log('   should be skipped, skipping...')
     return false
   }
 
@@ -20,8 +23,11 @@ function predicate(fieldProps) {
   const hasEmptyValue = value === ''
 
   if (!isCheckbox && hasEmptyValue) {
+    console.log('  is not a checkbox and has empty value')
     return false
   }
+
+  console.log('   satisfies predicate', fieldProps)
 
   return true
 }
@@ -29,15 +35,12 @@ function predicate(fieldProps) {
 /**
  * Serializes the provided fields. Returns
  * @param {Map} fields
- * @param {Boolean} withImmutable
+ * @param {Object} options
  * @param {Function} transformValue
  * @returns {Map}
  */
-export default function serializeFields(
-  fields,
-  withImmutable,
-  transformValue = recordUtils.getValue,
-) {
-  const serialized = flattenDeep(fields, predicate, false, transformValue)
-  return withImmutable ? serialized : serialized.toJS()
+export default function serializeFields(fields, transformValue = recordUtils.getValue) {
+  console.warn('serialize')
+  console.log('should serialize:', fields)
+  return flattenDeep(fields, predicate, false, transformValue)
 }

--- a/src/utils/flushFieldRefs.test.js
+++ b/src/utils/flushFieldRefs.test.js
@@ -5,12 +5,14 @@ import flushFieldRefs from './flushFieldRefs'
 
 const fieldOne = recordUtils.createField({
   name: 'fieldOne',
+  fieldPath: ['fieldOne'],
   value: 'foo',
 })
 
 const fieldTwo = recordUtils.createField({
   name: 'fieldTwo',
   fieldGroup: ['groupTwo'],
+  fieldPath: ['groupTwo', 'fieldTwo'],
   value: 'bar',
 })
 

--- a/src/utils/formUtils/mergeRules.js
+++ b/src/utils/formUtils/mergeRules.js
@@ -1,21 +1,21 @@
-import { fromJS, Map } from 'immutable'
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft'
+// import { fromJS, Map } from 'immutable'
 
 /**
  * Returns the iterable instance of form rules based on the provided proprietary rules
  * and the inherited context rules.
  * @param {Object} formRules
- * @param {Map} contextRules
- * @returns {Map}
+ * @param {Object} contextRules
+ * @returns {Object}
  */
-export default function mergeRules(formRules, contextRules = Map()) {
+export default function mergeRules(formRules, contextRules = {}) {
   if (!formRules) {
     return contextRules
   }
 
-  const iterableRules = fromJS(formRules)
-  const closestRules = iterableRules || contextRules
+  const closestRules = formRules || contextRules
 
-  return iterableRules.get('extend')
-    ? contextRules.mergeDeep(iterableRules)
+  return closestRules.extend
+    ? mergeDeepLeft(closestRules, contextRules)
     : closestRules
 }

--- a/src/utils/getLeaves.js
+++ b/src/utils/getLeaves.js
@@ -1,0 +1,20 @@
+import is from 'ramda/src/is'
+import when from 'ramda/src/when'
+import compose from 'ramda/src/compose'
+import chain from 'ramda/src/chain'
+import values from 'ramda/src/values'
+import allPass from 'ramda/src/allPass'
+import curry from 'ramda/src/curry'
+
+/**
+ * Accepts an object and returns a list of its leaves.
+ */
+const getLeaves = when(
+  is(Object),
+  compose(
+    (vals) => chain(getLeaves, vals),
+    values,
+  ),
+)
+
+export default getLeaves

--- a/src/utils/getLeaves.test.js
+++ b/src/utils/getLeaves.test.js
@@ -1,0 +1,16 @@
+import getLeaves, { getLeavesWith } from './getLeaves'
+
+test('Returns all leaves of the given object', () => {
+  const res = getLeaves({
+    a: 1,
+    b: {
+      c: 2,
+      d: {
+        e: 3,
+      },
+      f: 4,
+    },
+  })
+
+  expect(res).toEqual([1, 2, 3, 4])
+})

--- a/src/utils/recordUtils.js
+++ b/src/utils/recordUtils.js
@@ -5,6 +5,7 @@
  * the next state of the field record.
  */
 import curry from 'ramda/src/curry'
+import assocPath from 'ramda/src/assocPath'
 import { Record } from 'immutable'
 
 /**
@@ -27,6 +28,7 @@ const generateFieldClass = (initialProps) => {
       /* Internal */
       ref: null,
       fieldGroup: null,
+      fieldPath: null,
 
       /* Basic */
       type: 'text',
@@ -69,10 +71,10 @@ const generateFieldClass = (initialProps) => {
   )
 
   return class Field extends FieldRecord {
-    get fieldPath() {
-      const fieldGroup = this.fieldGroup || []
-      return fieldGroup.concat(this.name)
-    }
+    // get fieldPath() {
+    //   const fieldGroup = this.fieldGroup || []
+    //   return fieldGroup.concat(this.name)
+    // }
 
     get displayFieldPath() {
       return this.fieldPath.join('.')
@@ -96,7 +98,7 @@ export const createField = (initialProps) => {
  * @param {Map} collection
  */
 export const updateCollectionWith = curry((fieldProps, collection) => {
-  return collection.setIn(fieldProps.fieldPath, fieldProps)
+  return assocPath(fieldProps.fieldPath, fieldProps, collection)
 })
 
 /**
@@ -105,7 +107,7 @@ export const updateCollectionWith = curry((fieldProps, collection) => {
  * @returns {any}
  */
 export const getValue = (fieldProps) => {
-  return fieldProps.get(fieldProps.get('valuePropName'))
+  return fieldProps[fieldProps.valuePropName]
 }
 
 /**

--- a/src/utils/recordUtils.test.js
+++ b/src/utils/recordUtils.test.js
@@ -1,14 +1,17 @@
-import { Map, Record } from 'immutable'
+import * as R from 'ramda'
+import { Record } from 'immutable'
 import * as recordUtils from './recordUtils'
 
 const inputField = recordUtils.createField({
   name: 'fieldOne',
+  fieldPath: ['fieldOne'],
   value: 'foo',
   valuePropName: 'value',
 })
 
 const checkboxField = recordUtils.createField({
   name: 'checkboxOne',
+  fieldPath: ['checkboxOne'],
   type: 'checkbox',
   checked: true,
   valuePropName: 'checked',
@@ -30,8 +33,8 @@ describe('recordUtils', () => {
   })
 
   it('updateCollectionWith', () => {
-    const nextCollection = recordUtils.updateCollectionWith(inputField, Map())
-    expect(nextCollection.getIn(inputField.fieldPath)).toEqual(inputField)
+    const nextCollection = recordUtils.updateCollectionWith(inputField, {})
+    expect(R.path(inputField.fieldPath, nextCollection)).toEqual(inputField)
   })
 
   it('getValue', () => {

--- a/src/utils/rxUtils/createPropsSubscriptions.js
+++ b/src/utils/rxUtils/createPropsSubscriptions.js
@@ -1,3 +1,6 @@
+import path from 'ramda/src/path'
+import assocPath from 'ramda/src/assocPath'
+
 import dispatch from '../dispatch'
 import * as recordUtils from '../recordUtils'
 import createRuleResolverArgs from '../validation/createRuleResolverArgs'
@@ -27,8 +30,8 @@ export default function createPropsSubscriptions({ fieldProps, fields, form }) {
         const { fields } = form.state
         const { fieldPath: targetFieldPath } = nextTargetRecord
 
-        const currentSubscriberRecord = fields.getIn(subscriberFieldPath)
-        const nextFields = fields.set(targetFieldPath, nextTargetRecord)
+        const currentSubscriberRecord = path(subscriberFieldPath, fields)
+        const nextFields = assocPath(targetFieldPath, nextTargetRecord, fields)
 
         const nextResolverArgs = createRuleResolverArgs({
           fieldProps,
@@ -47,9 +50,10 @@ export default function createPropsSubscriptions({ fieldProps, fields, form }) {
           currentSubscriberRecord.set(rxPropName, nextPropValue),
         )
 
-        const updatedFields = nextFields.setIn(
+        const updatedFields = assocPath(
           subscriberFieldPath,
           nextSubscriberRecord,
+          nextFields,
         )
 
         if (shouldValidate) {

--- a/src/utils/validation/getFieldRules.js
+++ b/src/utils/validation/getFieldRules.js
@@ -3,14 +3,14 @@
  * applicable to the given field.
  */
 export const getRulesBySelector = (selector, fieldProps, schema) => {
-  const keyPath = [selector, fieldProps.get(selector)]
+  const keyPath = [selector, fieldProps[selector]]
 
   //
   // TODO
   // Shallow keyed collection is not a usual behavior, but only suitable
   // for the reduced schema into "rxRules". Think of the unified interface.
   //
-  return schema.get(keyPath.join('.'))
+  return schema[keyPath.join('.')]
 }
 
 /**


### PR DESCRIPTION
* Fixes #245 
* Partially relates to #272 

## Changes
- Adds `onSerialize` form prop to apply transformations to the serialized fields object
- Uses plain Object instead of Map for `fields` in form's state
- Uses plain Object instead of Map for `rules` in form props
- Removes immutable interfaces usage throughout the code base