### PR TITLE
Handles multiple validation resolvers 

### DIFF
--- a/cypress/integration/basics/Interactions.controlled.spec.jsx
+++ b/cypress/integration/basics/Interactions.controlled.spec.jsx
@@ -6,7 +6,10 @@ describe('Controlled fields interactions', function() {
   before(() => {
     cy.loadStory(<Scenario getRef={(form) => (this.form = form)} />)
   })
-  afterEach(() => this.form.reset())
+  afterEach(() => {
+    this.form.reset()
+    cy.wait(50)
+  })
 
   it('Mounts with proper initial state', () => {
     cy.get('#form').should(() => {

--- a/cypress/integration/basics/Interactions.uncontrolled.spec.jsx
+++ b/cypress/integration/basics/Interactions.uncontrolled.spec.jsx
@@ -9,6 +9,7 @@ describe('Uncontrolled fields interactions', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Mounts with proper initial state', () => {

--- a/cypress/integration/basics/Submit.spec.jsx
+++ b/cypress/integration/basics/Submit.spec.jsx
@@ -84,6 +84,7 @@ describe('Submit', () => {
 
     afterEach(() => {
       this.form.reset()
+      cy.wait(50)
       callbacksCalled = resetCallbackCalls(callbacksCalled)
     })
 

--- a/cypress/integration/basics/Submit.spec.jsx
+++ b/cypress/integration/basics/Submit.spec.jsx
@@ -22,8 +22,12 @@ describe('Submit', () => {
     cy.loadStory(<Scenario onSubmitStart={() => submitCount++} />)
   })
 
+  afterEach(() => {
+    submitCount = 0
+  })
+
   it('Prevents form submit unless all fields are expected', () => {
-    cy.wait(20)
+    cy.wait(100)
     submit()
     cy.getField('email').valid(false)
     cy.getField('password').valid(false)
@@ -43,6 +47,7 @@ describe('Submit', () => {
       .typeIn('bar')
       .valid()
     submit()
+
     cy.getField('termsAndConditions').valid(false)
     expect(submitCount).to.equal(0)
 
@@ -50,11 +55,9 @@ describe('Submit', () => {
       .markChecked()
       .valid()
 
-    cy.get('button[type="submit"]')
-      .click()
-      .then(() => {
-        expect(submitCount).to.equal(1)
-      })
+    submit().then(() => {
+      expect(submitCount).to.equal(1)
+    })
   })
 
   describe('Callback methods', function() {

--- a/cypress/integration/validation/async/index.js
+++ b/cypress/integration/validation/async/index.js
@@ -8,6 +8,7 @@ describe('Asynchronous validation', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Bypasses async validation for empty optional field with async rule', () => {

--- a/cypress/integration/validation/composite/index.js
+++ b/cypress/integration/validation/composite/index.js
@@ -51,4 +51,26 @@ describe('Composite validation', function() {
       .validSync()
       .validAsync()
   })
+
+  it('Supports multiple resolvers for a single selector', () => {
+    cy.getField('userPassword')
+      /* Asserting invalid when empty */
+      .focus()
+      .blur({ force: true })
+      .invalid()
+      /* Asserting none rules passed */
+      .focus()
+      .type('completely wrong value')
+      .expected(false)
+      .clear('')
+      /* Asserting the first rule passed */
+      .type('P')
+      .expected(false)
+      /* Asserting the second rule passed */
+      .type('roper')
+      .expected(false)
+      /* Asserting all rules passed */
+      .type('123')
+      .expected(true)
+  })
 })

--- a/cypress/integration/validation/composite/index.js
+++ b/cypress/integration/validation/composite/index.js
@@ -9,6 +9,7 @@ describe('Composite validation', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Bypasses async validation when preceding sync validation rejects', () => {

--- a/cypress/integration/validation/messages/AsyncExtraParam.spec.jsx
+++ b/cypress/integration/validation/messages/AsyncExtraParam.spec.jsx
@@ -8,6 +8,7 @@ describe('Async extra param', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Displays error message with "extra" params from response', () => {

--- a/cypress/integration/validation/messages/SetErrors.spec.jsx
+++ b/cypress/integration/validation/messages/SetErrors.spec.jsx
@@ -12,6 +12,7 @@ describe('Form-wide errors', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Sets error messages for fields using form ref', () => {

--- a/cypress/integration/validation/sync/Field.props.rule.spec.jsx
+++ b/cypress/integration/validation/sync/Field.props.rule.spec.jsx
@@ -8,6 +8,7 @@ describe('Field rules', function() {
 
   afterEach(() => {
     this.form.reset()
+    cy.wait(50)
   })
 
   it('Resolves empty optional field with sync rule', () => {

--- a/examples/full/RegistrationForm/RegistrationForm.jsx
+++ b/examples/full/RegistrationForm/RegistrationForm.jsx
@@ -6,7 +6,7 @@ import Button from '@shared/Button'
 export default class RegistrationForm extends React.Component {
   registerUser = ({ serialized }) => {
     console.log(serialized)
-    return new Promise(resolve => resolve())
+    return new Promise((resolve) => resolve())
   }
 
   render() {
@@ -18,22 +18,32 @@ export default class RegistrationForm extends React.Component {
             <Input name="userEmail" type="email" label="E-mail" required />
           </Field.Group>
 
-          <Input name="userPassword" type="password" label="Password" required />
-          <Input name="confirmPassword" type="password" label="Confirm password" required />
+          <Input
+            name="userPassword"
+            type="password"
+            label="Password"
+            required
+          />
+          <Input
+            name="confirmPassword"
+            type="password"
+            label="Confirm password"
+            required
+          />
 
           <Field.Group name="primaryInfo">
             <Input
               name="firstName"
               label="First name"
-              required={({ fields }) => {
-                return !!fields.primaryInfo.lastName.value
+              required={({ get }) => {
+                return !!get(['primaryInfo', 'lastName', 'value'])
               }}
             />
             <Input
               name="lastName"
               label="Last name"
-              required={({ fields }) => {
-                return !!fields.primaryInfo.firstName.value
+              required={({ get }) => {
+                return !!get(['primaryInfo', 'firstName', 'value'])
               }}
             />
           </Field.Group>

--- a/examples/full/RegistrationForm/validation-rules.js
+++ b/examples/full/RegistrationForm/validation-rules.js
@@ -12,8 +12,8 @@ export default {
 
   name: {
     confirmPassword: {
-      matches: ({ value, fields }) => {
-        return value === fields.userPassword.value
+      matches: ({ value, get }) => {
+        return value === get(['userPassword', 'value'])
       },
     },
   },

--- a/examples/validation/combined/index.jsx
+++ b/examples/validation/combined/index.jsx
@@ -2,6 +2,16 @@ import React from 'react'
 import { Form } from '@lib'
 import { Input } from '@fields'
 
+const validationRules = {
+  type: {
+    email: {
+      oneNumber: ({ value }) => /[0-9]/.test(value),
+      capitalLetter: ({ value }) => /[A-Z]/.test(value),
+      minLength: ({ value }) => value.length > 5,
+    },
+  },
+}
+
 export default class CombinedValidation extends React.Component {
   validateAsync = ({ value }) => {
     return new Promise((resolve) => {
@@ -15,7 +25,7 @@ export default class CombinedValidation extends React.Component {
 
   render() {
     return (
-      <Form ref={this.props.getRef}>
+      <Form ref={this.props.getRef} rules={validationRules}>
         <Input
           name="fieldOne"
           rule={/^\d+$/}
@@ -23,6 +33,7 @@ export default class CombinedValidation extends React.Component {
           label="Field one"
           hint="Numbers only (sync), not equal to 123 (async)"
         />
+        <Input name="userPassword" type="email" label="Password" required />
       </Form>
     )
   }

--- a/examples/validation/misc/AjaxPrefilling.jsx
+++ b/examples/validation/misc/AjaxPrefilling.jsx
@@ -3,7 +3,7 @@ import { Form } from '@lib'
 import { Input } from '@fields'
 import Button from '@shared/Button'
 
-export const timeoutDuration = 1200
+export const timeoutDuration = 500
 
 export default class AjaxPrefilling extends React.Component {
   state = {

--- a/src/utils/fieldUtils/createPropGetter.js
+++ b/src/utils/fieldUtils/createPropGetter.js
@@ -1,16 +1,20 @@
-import path from 'ramda/src/path'
+// @flow
+import * as R from 'ramda'
+
+type PropPath = string[]
+type CreatePropGetterCallback = (propPath: PropPath, propValue: mixed) => void
 
 /**
  * A thunk to generate a field prop getter function.
  * The latter is used for reactive props implementation and allows to flush
  * field prop references into a single source using a callback function.
- * @param {Object} fields
- * @param {Function?} callback
- * @returns {Function} A field prop getter function.
  */
-export default function createPropGetter(fields, callback) {
-  return (propPath) => {
-    const propValue = path(propPath, fields)
+export default function createPropGetter(
+  fields: Object,
+  callback: CreatePropGetterCallback,
+) {
+  return (propPath: PropPath) => {
+    const propValue = R.path(propPath, fields)
 
     if (callback) {
       callback(propPath, propValue)

--- a/src/utils/fieldUtils/createPropGetter.js
+++ b/src/utils/fieldUtils/createPropGetter.js
@@ -13,7 +13,7 @@ export default function createPropGetter(
   fields: Object,
   callback: CreatePropGetterCallback,
 ) {
-  return (propPath: PropPath) => {
+  return (propPath: PropPath): mixed => {
     const propValue = R.path(propPath, fields)
 
     if (callback) {

--- a/src/utils/flushFieldRefs.js
+++ b/src/utils/flushFieldRefs.js
@@ -13,10 +13,10 @@ type FieldRefs = {
  */
 export default function flushFieldRefs(func: Function, args: mixed): FieldRefs {
   const refs = []
-  const fieldPropGetter = createPropGetter(args.fields, refs.push)
+
   const initialValue = dispatch(func, {
     ...args,
-    get: fieldPropGetter,
+    get: createPropGetter(args.fields, (propRefPath) => refs.push(propRefPath)),
   })
 
   return { refs, initialValue }

--- a/src/utils/flushFieldRefs.js
+++ b/src/utils/flushFieldRefs.js
@@ -16,7 +16,9 @@ export default function flushFieldRefs(func: Function, args: mixed): FieldRefs {
 
   const initialValue = dispatch(func, {
     ...args,
-    get: createPropGetter(args.fields, (propRefPath) => refs.push(propRefPath)),
+    get: createPropGetter(args.form.state.fields, (propRefPath) =>
+      refs.push(propRefPath),
+    ),
   })
 
   return { refs, initialValue }

--- a/src/utils/flushFieldRefs.js
+++ b/src/utils/flushFieldRefs.js
@@ -2,7 +2,7 @@
 import dispatch from './dispatch'
 import createPropGetter from './fieldUtils/createPropGetter'
 
-type TFieldRefs = {
+type FieldRefs = {
   refs: string[][],
   initialValue: mixed,
 }
@@ -11,12 +11,9 @@ type TFieldRefs = {
  * Returns the map of flushed field props paths referenced within
  * the provided method, and its initial value.
  */
-export default function flushFieldRefs(func: Function, args: mixed): TFieldRefs {
+export default function flushFieldRefs(func: Function, args: mixed): FieldRefs {
   const refs = []
-  const fieldPropGetter = createPropGetter(args.fields, (propRefPath) =>
-    refs.push(propRefPath),
-  )
-
+  const fieldPropGetter = createPropGetter(args.fields, refs.push)
   const initialValue = dispatch(func, {
     ...args,
     get: fieldPropGetter,

--- a/src/utils/flushFieldRefs.test.js
+++ b/src/utils/flushFieldRefs.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai'
 import * as recordUtils from './recordUtils'
 import flushFieldRefs from './flushFieldRefs'
 
@@ -21,8 +20,8 @@ const fields = recordUtils.updateCollectionWith(
 )
 
 const method = ({ a, get }) => {
-  expect(a).to.equal('value')
-  expect(get).to.be.an.instanceOf(Function)
+  expect(a).toEqual('value')
+  expect(get).toBeInstanceOf(Function)
 
   const valueOne = get(['fieldOne', 'value'])
   const valueTwo = get(['groupTwo', 'fieldTwo', 'value'])
@@ -44,16 +43,13 @@ const methodArgs = {
 test('Returns proper collection of field refs', () => {
   const { refs } = flushFieldRefs(method, methodArgs)
 
-  expect(refs)
-    .to.be.an.instanceOf(Array)
-    .with.lengthOf(2)
-    .that.deep.equals([
-      ['fieldOne', 'value'],
-      ['groupTwo', 'fieldTwo', 'value'],
-    ])
+  expect(refs).toEqual([
+    ['fieldOne', 'value'],
+    ['groupTwo', 'fieldTwo', 'value'],
+  ])
 })
 
 test('Returns proper initial value', () => {
   const { initialValue } = flushFieldRefs(method, methodArgs)
-  expect(initialValue).to.equal('foobar')
+  expect(initialValue).toEqual('foobar')
 })

--- a/src/utils/flushFieldRefs.test.js
+++ b/src/utils/flushFieldRefs.test.js
@@ -34,6 +34,9 @@ const methodArgs = {
   a: 'value',
   fields,
   form: {
+    state: {
+      fields,
+    },
     context: {},
   },
 }

--- a/src/utils/formUtils/filterSchemaByField.js
+++ b/src/utils/formUtils/filterSchemaByField.js
@@ -1,24 +1,61 @@
+// @flow
 import * as R from 'ramda'
 
-const getRulesPaths = (fieldProps) => [
+export type ResolverRecord = {
+  keyPath: string[],
+  selector: string,
+  resolver: Function,
+}
+
+const getRulesPaths = (fieldProps: Object) => [
   ['name', fieldProps.name],
   ['type', fieldProps.type],
 ]
 
+const createRuleRecord = ([resolver, keyPath]): ResolverRecord => ({
+  keyPath,
+  selector: R.head(keyPath),
+  resolver,
+})
+
+const projectResolvers = ([resolver, keyPath]) => {
+  if (typeof resolver === 'function') {
+    return [[resolver, keyPath]]
+  }
+
+  return Object.entries(resolver).map(([ruleName, resolver]) => {
+    return [resolver, keyPath]
+  })
+}
+
+const debug = (message) => (a) => {
+  console.log(message, a)
+  return a
+}
+
 /**
- * Returns the list of validators applicable to the given field.
- * @param {Object} fieldProps
- * @param {Object} validationSchema
- * @returns {Function[]}
+ * Returns the list of resolver records from the given validation schema
+ * applicable to the given field.
  */
-const filterSchemaByField = (fieldProps, validationSchema) =>
+const filterSchemaByField = (
+  fieldProps: Object,
+  validationSchema: Object,
+): ResolverRecord[] =>
   R.compose(
-    R.map(([resolver, keyPath]) => ({
-      keyPath,
-      selector: R.head(keyPath),
-      resolver,
-    })),
+    /* Create rule record from the list of resolvers */
+    debug('result'),
+    R.map(createRuleRecord),
+
+    /* Handle and flat map multiple resolvers */
+    debug('after chain'),
+    R.chain(projectResolvers),
+
+    debug('before chain'),
+
+    /* Filter out selectors that have no rules */
     R.filter(R.head),
+
+    /* Grab resolvers based on paths from the schema */
     R.map((keyPath) => [R.path(keyPath, validationSchema), keyPath]),
     getRulesPaths,
   )(fieldProps)

--- a/src/utils/formUtils/filterSchemaByField.js
+++ b/src/utils/formUtils/filterSchemaByField.js
@@ -2,12 +2,13 @@
 import * as R from 'ramda'
 
 export type ResolverRecord = {
+  name?: string,
   keyPath: string[],
   selector: string,
   resolver: Function,
 }
 
-type ResolverTuple = [Function, string[]]
+type ResolverTuple = [Function, string[], string]
 
 const getRulesPaths = (fieldProps: Object) => [
   ['name', fieldProps.name],
@@ -17,7 +18,9 @@ const getRulesPaths = (fieldProps: Object) => [
 const createResolverRecord = ([
   resolver,
   keyPath,
+  ruleName,
 ]: ResolverTuple): ResolverRecord => ({
+  name: ruleName,
   keyPath,
   selector: R.head(keyPath),
   resolver,
@@ -28,8 +31,8 @@ const projectResolvers = ([resolver, keyPath]: ResolverTuple) => {
     return [[resolver, keyPath]]
   }
 
-  return Object.entries(resolver).map(([ruleName, resolver]) => {
-    return [resolver, keyPath]
+  return Object.entries(resolver).map(([ruleName, namedResolver]) => {
+    return [namedResolver, keyPath, ruleName]
   })
 }
 

--- a/src/utils/formUtils/filterSchemaByField.js
+++ b/src/utils/formUtils/filterSchemaByField.js
@@ -9,10 +9,6 @@ export type ResolverRecord = {
 
 type ResolverTuple = [Function, string[]]
 
-type FilterSchemaByField = (
-  validationSchema: Object,
-) => (fieldProps: Object) => ResolverRecord[]
-
 const getRulesPaths = (fieldProps: Object) => [
   ['name', fieldProps.name],
   ['type', fieldProps.type],
@@ -41,20 +37,22 @@ const projectResolvers = ([resolver, keyPath]: ResolverTuple) => {
  * Returns the list of resolver records from the given validation schema
  * applicable to the given field.
  */
-const filterSchemaByField: FilterSchemaByField = (validationSchema) =>
-  R.compose(
-    /* Create the list of resolver records from the list of resolvers */
-    R.map(createResolverRecord),
+const filterSchemaByField = R.curry(
+  (validationSchema: Object, fieldProps: Object): ResolverRecord[] =>
+    R.compose(
+      /* Create the list of resolver records from the list of resolvers */
+      R.map(createResolverRecord),
 
-    /* Flat map multiple resolvers */
-    R.chain(projectResolvers),
+      /* Flat map multiple resolvers */
+      R.chain(projectResolvers),
 
-    /* Filter out selectors that have no resolvers */
-    R.filter(R.head),
+      /* Filter out selectors that have no resolvers */
+      R.filter(R.head),
 
-    /* Grab resolvers based on the paths from the schema */
-    R.map((keyPath) => [R.path(keyPath, validationSchema), keyPath]),
-    getRulesPaths,
-  )
+      /* Grab resolvers based on the paths from the schema */
+      R.map((keyPath) => [R.path(keyPath, validationSchema), keyPath]),
+      getRulesPaths,
+    )(fieldProps),
+)
 
 export default filterSchemaByField

--- a/src/utils/formUtils/filterSchemaByField.js
+++ b/src/utils/formUtils/filterSchemaByField.js
@@ -28,11 +28,6 @@ const projectResolvers = ([resolver, keyPath]) => {
   })
 }
 
-const debug = (message) => (a) => {
-  console.log(message, a)
-  return a
-}
-
 /**
  * Returns the list of resolver records from the given validation schema
  * applicable to the given field.
@@ -43,14 +38,10 @@ const filterSchemaByField = (
 ): ResolverRecord[] =>
   R.compose(
     /* Create rule record from the list of resolvers */
-    debug('result'),
     R.map(createRuleRecord),
 
     /* Handle and flat map multiple resolvers */
-    debug('after chain'),
     R.chain(projectResolvers),
-
-    debug('before chain'),
 
     /* Filter out selectors that have no rules */
     R.filter(R.head),

--- a/src/utils/formUtils/filterSchemaByField.test.js
+++ b/src/utils/formUtils/filterSchemaByField.test.js
@@ -118,11 +118,13 @@ test('Handles multiple resolvers on a single relevant selector', () => {
 
   expect(res).toEqual([
     {
+      name: 'ruleOne',
       selector: 'name',
       keyPath: ['name', 'fieldOne'],
       resolver: ruleOne,
     },
     {
+      name: 'ruleTwo',
       selector: 'name',
       keyPath: ['name', 'fieldOne'],
       resolver: ruleTwo,

--- a/src/utils/formUtils/filterSchemaByField.test.js
+++ b/src/utils/formUtils/filterSchemaByField.test.js
@@ -1,0 +1,136 @@
+import * as recordUtils from '../recordUtils'
+import filterSchemaByField from './filterSchemaByField'
+
+const fieldOne = recordUtils.createField({
+  name: 'fieldOne',
+})
+
+test('Returns empty list when no applicable rules are found', () => {
+  const res = filterSchemaByField(
+    {
+      type: {
+        email: ({ value }) => value,
+      },
+      name: {
+        fieldTwo: ({ value }) => value,
+      },
+    },
+    fieldOne,
+  )
+
+  expect(res).toEqual([])
+})
+
+test('Returns relative type-specific rules', () => {
+  const textRule = () => true
+
+  const res = filterSchemaByField(
+    {
+      type: {
+        text: textRule,
+      },
+      name: {
+        fieldTwo: () => true,
+      },
+    },
+    fieldOne,
+  )
+
+  expect(res).toEqual([
+    {
+      keyPath: ['type', 'text'],
+      selector: 'type',
+      resolver: textRule,
+    },
+  ])
+})
+
+test('Returns relative name-specific rules', () => {
+  const namedRule = () => true
+
+  const res = filterSchemaByField(
+    {
+      name: {
+        fieldOne: namedRule,
+      },
+    },
+    fieldOne,
+  )
+
+  expect(res).toEqual([
+    {
+      keyPath: ['name', 'fieldOne'],
+      selector: 'name',
+      resolver: namedRule,
+    },
+  ])
+})
+
+test('Returns relative type and name specific rules', () => {
+  const textRule = () => true
+  const namedRule = () => true
+
+  const res = filterSchemaByField(
+    {
+      type: {
+        text: textRule,
+      },
+      name: {
+        fieldOne: namedRule,
+      },
+    },
+    fieldOne,
+  )
+
+  expect(res).toEqual([
+    {
+      keyPath: ['name', 'fieldOne'],
+      selector: 'name',
+      resolver: namedRule,
+    },
+    {
+      keyPath: ['type', 'text'],
+      selector: 'type',
+      resolver: textRule,
+    },
+  ])
+})
+
+test('Handles multiple resolvers on a single relevant selector', () => {
+  const textRule = () => true
+  const ruleOne = () => true
+  const ruleTwo = () => true
+
+  const res = filterSchemaByField(
+    {
+      type: {
+        text: textRule,
+      },
+      name: {
+        fieldOne: {
+          ruleOne,
+          ruleTwo,
+        },
+      },
+    },
+    fieldOne,
+  )
+
+  expect(res).toEqual([
+    {
+      selector: 'name',
+      keyPath: ['name', 'fieldOne'],
+      resolver: ruleOne,
+    },
+    {
+      selector: 'name',
+      keyPath: ['name', 'fieldOne'],
+      resolver: ruleTwo,
+    },
+    {
+      selector: 'type',
+      keyPath: ['type', 'text'],
+      resolver: textRule,
+    },
+  ])
+})

--- a/src/utils/formUtils/getRulesRefs.js
+++ b/src/utils/formUtils/getRulesRefs.js
@@ -7,14 +7,13 @@ import flushFieldRefs from '../flushFieldRefs'
  * Iterates over the list of field rules, flushes fields references
  * from each resolver function and adds "refs" property to each rule.
  */
-const getRulesRefs = (
-  resolverArgs: Object,
-  resolverRecords: ResolverRecord[],
-): Object[] => {
-  return R.map((rule) => {
-    const { refs } = flushFieldRefs(rule.resolver, resolverArgs)
-    return R.assoc('refs', refs, rule)
-  })(resolverRecords)
-}
+const getRulesRefs = R.curry(
+  (resolverArgs: Object, resolverRecords: ResolverRecord[]): Object[] => {
+    return R.map((rule) => {
+      const { refs } = flushFieldRefs(rule.resolver, resolverArgs)
+      return R.assoc('refs', refs, rule)
+    })(resolverRecords)
+  },
+)
 
 export default getRulesRefs

--- a/src/utils/formUtils/getRulesRefs.js
+++ b/src/utils/formUtils/getRulesRefs.js
@@ -1,18 +1,20 @@
+// @flow
+import type { ResolverRecord } from './filterSchemaByField'
 import * as R from 'ramda'
 import flushFieldRefs from '../flushFieldRefs'
 
 /**
  * Iterates over the list of field rules, flushes fields references
  * from each resolver function and adds "refs" property to each rule.
- * @param {Object} resolverArgs
- * @param {Object[]} fieldRules
- * @returns {Object[]}
  */
-const getRulesRefs = (resolverArgs, fieldRules) => {
+const getRulesRefs = (
+  resolverArgs: Object,
+  resolverRecords: ResolverRecord[],
+): Object[] => {
   return R.map((rule) => {
     const { refs } = flushFieldRefs(rule.resolver, resolverArgs)
     return R.assoc('refs', refs, rule)
-  })(fieldRules)
+  })(resolverRecords)
 }
 
 export default getRulesRefs

--- a/src/utils/formUtils/mergeRules.js
+++ b/src/utils/formUtils/mergeRules.js
@@ -13,6 +13,7 @@ export default function mergeRules(validationSchema, contextRules = {}) {
   }
 
   const closestRules = validationSchema || contextRules
+
   return closestRules.extend
     ? R.mergeDeepRight(closestRules, contextRules)
     : closestRules

--- a/src/utils/reduceWhile.test.js
+++ b/src/utils/reduceWhile.test.js
@@ -1,0 +1,74 @@
+import * as recordUtils from './recordUtils'
+import validateSync from './validation/validateSync'
+import createRuleResolverArgs from './validation/createRuleResolverArgs'
+import reduceWhile, { reduceWhileExpected } from './reduceWhile'
+
+test('Reduces the list while predicate returns true', (done) => {
+  const numbers = [2, 3, 4, 5]
+  const lessThanTen = (acc) => acc < 10
+  const reduceNumbers = reduceWhile(
+    lessThanTen,
+    (acc, number, externalNumber) => {
+      return acc + number + externalNumber
+    },
+    0,
+    numbers,
+  )
+
+  reduceNumbers(2).then((res) => {
+    expect(res).toBe(15)
+    done()
+  })
+})
+
+test('Reduces validators while they resolve to expected', (done) => {
+  const validatorsList = [validateSync]
+  const fieldProps = recordUtils.createField({
+    name: 'fieldOne',
+    fieldPath: ['fieldOne'],
+    value: 'foo',
+  })
+  const resolverArgs = createRuleResolverArgs({
+    fieldProps,
+    form: {
+      state: {
+        applicableRules: {
+          type: {
+            text: [
+              {
+                keyPath: ['type', 'text'],
+                selector: 'type',
+                resolver: ({ value }) => value !== 'foo',
+              },
+            ],
+          },
+          name: {
+            fieldOne: [
+              {
+                keyPath: ['name', 'fieldOne'],
+                selector: 'name',
+                resolver: ({ value }) => value.length > 2,
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
+
+  const validate = reduceWhileExpected(validatorsList)
+
+  validate(resolverArgs).then((res) => {
+    expect(res).toEqual({
+      expected: false,
+      validators: ['sync'],
+      rejectedRules: [
+        {
+          selector: 'type',
+          errorType: 'invalid',
+        },
+      ],
+    })
+    done()
+  })
+})

--- a/src/utils/rxUtils/createRulesSubscriptions.js
+++ b/src/utils/rxUtils/createRulesSubscriptions.js
@@ -66,6 +66,8 @@ export default function createRulesSubscriptions({ fieldProps, fields, form }) {
   })
 
   const fieldRules = filterSchemaByField(fieldProps, validationSchema)
+  console.log({ fieldRules })
+
   const nextFieldRules = getRulesRefs(resolverArgs, fieldRules)
   nextFieldRules.forEach(createRuleObservable(resolverArgs))
 

--- a/src/utils/rxUtils/makeObservable.js
+++ b/src/utils/rxUtils/makeObservable.js
@@ -77,10 +77,9 @@ export default function makeObservable(
   const formattedTargetRefs = formatRefs(refs)
 
   R.toPairs(formattedTargetRefs).forEach(([joinedFieldPath, props]) => {
-    //
-    // TODO
-    // This would be nice to improve to omit keys glue.
-    //
+    /**
+     * @todo Omit the keys glue.
+     */
     const targetFieldPath = joinedFieldPath.split('.')
 
     /**
@@ -90,9 +89,9 @@ export default function makeObservable(
      * validate to prevent invalid fields at initial form render.
      */
     const shouldValidate = !!recordUtils.getValue(subscriberProps)
-    const includesField = R.path(targetFieldPath, fields)
+    const isTargetRegistered = R.path(targetFieldPath, fields)
 
-    if (includesField) {
+    if (isTargetRegistered) {
       const subscription = createObserver({
         targetFieldPath,
         props,

--- a/src/utils/validation/applyRule.js
+++ b/src/utils/validation/applyRule.js
@@ -15,9 +15,9 @@ export default function applyRule(rule, resolverArgs) {
   const rejectedRules = isFieldExpected
     ? undefined
     : createRejectedRule({
-        errorType: errorType || errorTypes.invalid,
-        ruleName: name,
+        name,
         selector,
+        errorType: errorType || errorTypes.invalid,
       })
 
   return createValidationResult(isFieldExpected, rejectedRules)

--- a/src/utils/validation/createRejectedRule.js
+++ b/src/utils/validation/createRejectedRule.js
@@ -3,28 +3,28 @@ export type TRuleSelector = 'type' | 'name'
 export type TRuleName = string | void
 
 export type TRejectedRule = {
-  errorType: string,
+  name: TRuleName,
   selector: TRuleSelector,
-  ruleName: TRuleName,
+  errorType: string,
 }
 
 type TCreateRejectedRuleArgs = {
-  errorType: string,
+  name: TRuleName,
   selector: TRuleSelector,
-  ruleName: TRuleName,
+  errorType: string,
 }
 
 /**
  * Creates a rejected rule with the standardized shape.
  */
 export default function createRejectedRule({
-  errorType,
+  name,
   selector,
-  ruleName,
+  errorType,
 }: TCreateRejectedRuleArgs) {
   return {
-    errorType,
+    name,
     selector,
-    ruleName,
+    errorType,
   }
 }

--- a/src/utils/validation/getFieldRules.js
+++ b/src/utils/validation/getFieldRules.js
@@ -7,13 +7,10 @@ import path from 'ramda/src/path'
 export const getRulesBySelector = (selector, fieldProps, applicableRules) => {
   const keyPath = [selector, fieldProps[selector]]
 
-  //
-  // TODO
-  // Shallow keyed collection is not a usual behavior, but only suitable
-  // for the reduced schema into "applicableRules". Think of the unified interface.
-  //
-  // return applicableRules[keyPath.join('.')]
-
+  /**
+   * @todo Shallow keyed collection is not a usual behavior, but only suitable
+   * for the reduced schema into "applicableRules". Consider a unified interface.
+   */
   return path(keyPath, applicableRules)
 }
 

--- a/src/utils/validation/index.js
+++ b/src/utils/validation/index.js
@@ -3,7 +3,7 @@ import createRuleResolverArgs from './createRuleResolverArgs'
 import validateSync from './validateSync'
 import validateAsync from './validateAsync'
 
-const defaultValidatorsChain = [validateSync, validateAsync]
+const defaultValidatorsList = [validateSync, validateAsync]
 
 /**
  * Performs validation of the given field with the given parameters.
@@ -12,7 +12,7 @@ const defaultValidatorsChain = [validateSync, validateAsync]
 export default async function validate(args) {
   const { force, chain } = args
   const resolverArgs = createRuleResolverArgs(args)
-  const validatorsChain = chain || defaultValidatorsChain
+  const validatorsList = chain || defaultValidatorsList
 
-  return reduceWhileExpected(validatorsChain)(resolverArgs, force)
+  return reduceWhileExpected(validatorsList)(resolverArgs, force)
 }

--- a/src/utils/validation/messages/getMessages.test.js
+++ b/src/utils/validation/messages/getMessages.test.js
@@ -45,7 +45,7 @@ test('Resolvers type-specific named rejected rules', () => {
     createRejectedRule({
       selector: 'type',
       errorType: 'invalid',
-      ruleName: 'customRule',
+      name: 'customRule',
     }),
   ]
 
@@ -84,7 +84,7 @@ test('Multiple rejected rules of different resolvers length', () => {
     createRejectedRule({
       selector: 'name',
       errorType: 'invalid',
-      ruleName: 'customRule',
+      name: 'customRule',
     }),
     createRejectedRule({
       errorType: 'invalid',
@@ -110,7 +110,7 @@ test('Resolvers name-specific named rejected rules', () => {
     createRejectedRule({
       selector: 'name',
       errorType: 'invalid',
-      ruleName: 'customRule',
+      name: 'customRule',
     }),
   ]
 
@@ -160,7 +160,7 @@ test('Fallbacks to the general invalid message when no specific ones found', () 
     createRejectedRule({
       selector: 'type',
       errorType: 'invalid',
-      ruleName: 'customRule',
+      name: 'customRule',
     }),
   ]
 
@@ -181,7 +181,7 @@ test('Fallbacks to the general missing message when no specific ones found', () 
     createRejectedRule({
       selector: 'type',
       errorType: 'missing',
-      ruleName: 'customRule',
+      name: 'customRule',
     }),
   ]
 

--- a/src/utils/validation/messages/getResolvePaths.js
+++ b/src/utils/validation/messages/getResolvePaths.js
@@ -11,7 +11,7 @@ const namedRuleResolver = (rejectedRule: TRejectedRule, fieldProps) => [
   rejectedRule.selector,
   fieldProps[rejectedRule.selector],
   'rule',
-  rejectedRule.ruleName,
+  rejectedRule.name,
 ]
 
 const commonKeyPathGetters: KeyResolver[] = [
@@ -27,7 +27,7 @@ const commonKeyPathGetters: KeyResolver[] = [
 ]
 
 const isNamedRule = (rejectedRule: TRejectedRule) => {
-  return () => !!rejectedRule.ruleName
+  return () => !!rejectedRule.name
 }
 
 /**

--- a/src/utils/validation/validateAsync/applyFieldAsyncRule.js
+++ b/src/utils/validation/validateAsync/applyFieldAsyncRule.js
@@ -15,7 +15,9 @@ export default async function applyFieldAsyncRule(resolverArgs) {
    * Set pending async request reference on field props to be able
    * to cancel request upon field value change.
    */
-  form.updateFieldsWith(R.assoc('pendingAsyncValidation', pendingRequest, fieldProps))
+  form.updateFieldsWith(
+    R.assoc('pendingAsyncValidation', pendingRequest, fieldProps),
+  )
 
   const result = await pendingRequest.itself
 
@@ -24,7 +26,7 @@ export default async function applyFieldAsyncRule(resolverArgs) {
     ? undefined
     : createRejectedRule({
         selector: 'name',
-        ruleName: 'async',
+        name: 'async',
         errorType: errorTypes.invalid,
       })
 


### PR DESCRIPTION
* Fixes #294 

## Changes
- Added multiple resolvers support for a single selector in `filterSchemaByField`.
- Simplified `reduceWhile` declaration. Used composition to define derived methods.
- Added unit tests for `reduceWhile`.
- Added unit tests for `filterSchemaByField`.
- Added integration test for multiple resolvers for a single selector.

## Todo
- [x] ~~Rewrite `projectResolvers` using functional composition~~
- [x] Double check the reference of `args.fields` in `flushFieldRefs`. Fields from arguments are undefined sometimes.