### PR TITLE
webpack: Provides "globalObject" forcing to solve "window" in SSR

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,8 @@ module.exports = {
     library: 'reactAdvancedForm',
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    /** @see https://github.com/webpack/webpack/issues/6522 */
+    globalObject: `typeof self !== 'undefined' ? self : this`,
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
* Fixes #322 

## Roadmap

- [x] Perform a server build that includes `react-advanced-form`