### PR TITLE
createField: Makes "type" propagation explicit

### DIFF
--- a/cypress/integration/basics/Types.spec.js
+++ b/cypress/integration/basics/Types.spec.js
@@ -1,0 +1,40 @@
+describe('Field types', function() {
+  before(() => {
+    cy.loadStory(['Basics', 'Interaction', 'Uncontrolled fields'])
+  })
+
+  it('Sets "type: text" on inputs by default', () => {
+    cy.getField('inputOne').should('have.attr', 'type', 'text')
+    cy.getField('inputTwo').should('have.attr', 'type', 'text')
+    cy.getField('inputTwo').should('have.attr', 'type', 'text')
+  })
+
+  it('Sets custom "type" for Radio, Checkbox', () => {
+    cy.getField('radio')
+      .first()
+      .should('have.attr', 'type', 'radio')
+    cy.getField('checkboxOne').should('have.attr', 'type', 'checkbox')
+  })
+
+  it('Sets no "type" on Select, Textarea', () => {
+    cy.getField('select').should('not.have.attr', 'type')
+    cy.getField('textareaOne').should('not.have.attr', 'type')
+  })
+
+  describe('Custom field types', () => {
+    before(() => {
+      cy.loadStory(['Other', 'Full examples', 'Registration form'])
+    })
+
+    it('Sets custom "type" for inputs', () => {
+      cy.getField('userEmail').should('have.attr', 'type', 'email')
+      cy.getField('userPassword').should('have.attr', 'type', 'password')
+    })
+
+    it('Allows deviation of "type" on custom fields (BirthDate)', () => {
+      cy.getField('birthDate')
+        .first()
+        .should('have.attr', 'type', 'text')
+    })
+  })
+})

--- a/cypress/integration/basics/UncontrolledFields.spec.js
+++ b/cypress/integration/basics/UncontrolledFields.spec.js
@@ -12,26 +12,26 @@ describe('Uncontrolled fields', function() {
         inputTwo: 'foo',
         select: 'two',
         radio: 'potato',
-        checkbox1: false,
-        checkbox2: true,
+        checkboxOne: false,
+        checkboxTwo: true,
         textareaTwo: 'something',
       })
     })
   })
 
   it('Updates form state on field change', () => {
-    cy.get('#inputOne').type('first value')
-    cy.get('#inputTwo')
+    cy.getField('inputOne').type('first value')
+    cy.getField('inputTwo')
       .clear()
       .typeIn('second value')
     cy.get('#radio3').markChecked()
-    cy.get('#checkbox1').markChecked()
-    cy.get('#checkbox2').markUnchecked()
-    cy.get('#select').select('three')
-    cy.get('#textareaOne')
+    cy.getField('checkboxOne').markChecked()
+    cy.getField('checkboxTwo').markUnchecked()
+    cy.getField('select').select('three')
+    cy.getField('textareaOne')
       .clear()
       .typeIn('foo')
-    cy.get('#textareaTwo')
+    cy.getField('textareaTwo')
       .clear()
       .typeIn('another')
 
@@ -41,8 +41,8 @@ describe('Uncontrolled fields', function() {
         inputOne: 'first value',
         inputTwo: 'second value',
         radio: 'cucumber',
-        checkbox1: true,
-        checkbox2: false,
+        checkboxOne: true,
+        checkboxTwo: false,
         select: 'three',
         textareaOne: 'foo',
         textareaTwo: 'another',

--- a/cypress/integration/basics/index.js
+++ b/cypress/integration/basics/index.js
@@ -1,4 +1,5 @@
 describe('Basics', function() {
+  require('./Types.spec')
   require('./FieldUnmounting.spec')
   require('./InitialValues.spec')
   require('./SetValues.spec')

--- a/examples/basics/UncontrolledFields.jsx
+++ b/examples/basics/UncontrolledFields.jsx
@@ -41,14 +41,14 @@ export default class UncontrolledFields extends React.Component {
 
           {/* Checkboxes */}
           <Checkbox
-            id="checkbox1"
-            name="checkbox1"
+            id="checkboxOne"
+            name="checkboxOne"
             label="Checkbox one"
             checked={false}
           />
           <Checkbox
-            id="checkbox2"
-            name="checkbox2"
+            id="checkboxTwo"
+            name="checkboxTwo"
             label="Checkbox two"
             checked
           />

--- a/examples/fields/BirthDate.jsx
+++ b/examples/fields/BirthDate.jsx
@@ -83,6 +83,9 @@ export default createField({
     ...fieldRecord,
     type: 'birthDate',
   }),
+  enforceProps: () => ({
+    type: 'text',
+  }),
   /**
    * Execute mapping function each time a "raw" value ("1999-12-10")
    * comes into the field. Has no effect over internal field value handling.

--- a/examples/index.js
+++ b/examples/index.js
@@ -132,6 +132,6 @@ storiesOf('Other|Third-party fields', module)
   .add('react-datepicker', addComponent(<ReactDatepicker />))
 
 storiesOf('Other|Full examples', module).add(
-  'Registration Form',
+  'Registration form',
   addComponent(<RegistrationForm />),
 )

--- a/src/components/createField.jsx
+++ b/src/components/createField.jsx
@@ -77,7 +77,6 @@ export default function connectField(options) {
       }
 
       static defaultProps = {
-        type: 'text',
         disabled: false,
         required: false,
       }
@@ -130,8 +129,6 @@ export default function connectField(options) {
           getRef: () => this,
           fieldGroup,
           fieldPath: __fieldPath,
-          // name: prunedProps.name,
-          // type: prunedProps.type,
           valuePropName,
           [valuePropName]: hocOptions.mapValue(registeredValue),
           /**

--- a/src/fieldPresets/input.js
+++ b/src/fieldPresets/input.js
@@ -1,4 +1,8 @@
 export default {
+  mapPropsToField: ({ props, fieldRecord }) => ({
+    ...fieldRecord,
+    type: props.type || 'text',
+  }),
   enforceProps: ({ props }) => ({
     accept: props.accept,
     placeholder: props.placeholder,

--- a/src/utils/formUtils/filterSchemaByField.test.js
+++ b/src/utils/formUtils/filterSchemaByField.test.js
@@ -3,6 +3,7 @@ import filterSchemaByField from './filterSchemaByField'
 
 const fieldOne = recordUtils.createField({
   name: 'fieldOne',
+  type: 'text',
 })
 
 test('Returns empty list when no applicable rules are found', () => {

--- a/src/utils/recordUtils.js
+++ b/src/utils/recordUtils.js
@@ -23,7 +23,6 @@ export const createField = (initialState) => {
     fieldPath: null,
 
     /* Basic */
-    type: 'text',
     initialValue: value,
     [valuePropName]: value,
     valuePropName,

--- a/src/utils/recordUtils.test.js
+++ b/src/utils/recordUtils.test.js
@@ -4,6 +4,7 @@ import * as recordUtils from './recordUtils'
 const inputField = recordUtils.createField({
   name: 'fieldOne',
   fieldPath: ['fieldOne'],
+  type: 'text',
   value: 'foo',
 })
 

--- a/src/utils/reduceWhile.test.js
+++ b/src/utils/reduceWhile.test.js
@@ -25,6 +25,7 @@ test('Reduces validators while they resolve to expected', (done) => {
   const validatorsList = [validateSync]
   const fieldProps = recordUtils.createField({
     name: 'fieldOne',
+    type: 'text',
     fieldPath: ['fieldOne'],
     value: 'foo',
   })


### PR DESCRIPTION
* Closes #335 

This change is potentially breaking, thus should be released in the next minor version to prevent compatibility issues.

# Roadmap

- [x] Add integration test that asserts proper types of rendered fields