### PR TITLE
Fix: npm scripts - $(npm bin) wont execute on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "build": "npm run clean && cross-env NODE_ENV=production webpack",
     "build:storybook": "cross-env NODE_ENV=production build-storybook",
     "test:unit": "cross-env NODE_ENV=production jest",
-    "cypress": "$(npm bin)/cypress open -e envName=dev",
-    "cypress:cli": "$(npm bin)/cypress run --spec 'cypress/integration/index.js' --browser chrome",
-    "test:integration:dev": "$(npm bin)/cypress run -e envName=dev --spec cypress/integration/index.js --headed --no-exit",
+    "cypress": "node_modules/.bin/cypress open -e envName=dev",
+    "cypress:cli": "node_modules/.bin/cypress run --spec 'cypress/integration/index.js' --browser chrome",
+    "test:integration:dev": "node_modules/.bin/cypress run -e envName=dev --spec cypress/integration/index.js --headed --no-exit",
     "test:integration": "npm run cypress:cli",
     "test": "npm run test:unit",
     "prepublishOnly": "npm run build && npm test"


### PR DESCRIPTION
# What
 Windows CLI throws error while running the following npm scripts:
```bash
"cypress": "$(npm bin)/cypress open -e envName=dev",
"cypress:cli": "$(npm bin)/cypress run --spec 'cypress/integration/index.js' --browser chrome",
"test:integration:dev": "$(npm bin)/.bin/cypress run -e envName=dev --spec cypress/integration/index.js --headed --no-exit"
```
# Error

```bash
'$' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-advanced-form@1.6.7 cypress: `$(npm bin)/cypress open -e envName=dev`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-advanced-form@1.6.7 cypress script.
```
# Fix
Replaced `$(npm bin)` with `node_modules/.bin`