### PR TITLE
Fix behavior of `onFirstChange` callback with regard to `Form.reset()`

### DIFF
--- a/cypress/integration/basics/FirstChange.spec.js
+++ b/cypress/integration/basics/FirstChange.spec.js
@@ -1,0 +1,33 @@
+const reset = () => cy.get('#reset').click()
+
+describe('First change', () => {
+  before(() => {
+    cy.loadStory(['Basics', 'Interaction', 'First change'])
+  })
+
+  it('Calls "onFirstChange" when field changes', () => {
+    cy.get('#dirty').should('not.be.visible')
+    cy.get('#not-dirty').should('be.visible')
+
+    cy.getField('email')
+      .clear()
+      .typeIn('changed@email.example')
+
+    cy.get('#dirty').should('be.visible')
+    cy.get('#not-dirty').should('not.be.visible')
+  })
+
+  it('Calls "onFirstChange" again when form is reset and field changes', () => {
+    reset()
+
+    cy.get('#dirty').should('not.be.visible')
+    cy.get('#not-dirty').should('be.visible')
+
+    cy.getField('email')
+      .clear()
+      .typeIn('changed@email.example')
+
+    cy.get('#dirty').should('be.visible')
+    cy.get('#not-dirty').should('not.be.visible')
+  })
+})

--- a/cypress/integration/basics/index.js
+++ b/cypress/integration/basics/index.js
@@ -8,6 +8,6 @@ describe('Basics', function() {
   require('./ControlledFields.spec')
   require('./UncontrolledFields.spec')
   require('./Submit.spec')
-
   require('./DebouncedChange.spec')
+  require('./FirstChange.spec')
 })

--- a/examples/basics/FirstChange.jsx
+++ b/examples/basics/FirstChange.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Form } from 'react-advanced-form'
+import { Input } from '@examples/fields'
+import Button from '@examples/shared/Button'
+
+const initialState = {
+  isDirty: false,
+}
+
+export default class OnFirstChange extends React.Component {
+  state = initialState
+
+  resetForm = () => {
+    window.form.reset()
+  }
+
+  handleReset = () => {
+    this.setState(initialState)
+  }
+
+  handleFirstChange = () => {
+    this.setState({
+      isDirty: true,
+    })
+  }
+
+  render() {
+    const { isDirty } = this.state
+
+    return (
+      <React.Fragment>
+        <h1>First change</h1>
+
+        <Form
+          ref={(form) => (window.form = form)}
+          onReset={this.handleReset}
+          onFirstChange={this.handleFirstChange}
+        >
+          <Input
+            name="email"
+            type="email"
+            label="E-mail"
+            initialValue="initial@email.example"
+          />
+
+          <Button id="reset" type="reset" onClick={this.resetForm}>
+            Reset
+          </Button>
+
+          {isDirty ? (
+            <p id="dirty">Form is dirty</p>
+          ) : (
+            <p id="not-dirty">Form is not dirty</p>
+          )}
+        </Form>
+      </React.Fragment>
+    )
+  }
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -34,6 +34,7 @@ import ControlledFields from './basics/ControlledFields'
 import SubmitCallbacks from './basics/SubmitCallbacks'
 import Submit from './basics/Submit'
 import DebouncedChange from './basics/DebouncedChange'
+import FirstChange from './basics/FirstChange'
 
 /* Components */
 import CreateField from './components/createField'
@@ -98,6 +99,7 @@ storiesOf('Basics|Interaction', module)
   .add('Form submit', addComponent(<Submit />))
   .add('Submit callbacks', addComponent(<SubmitCallbacks />))
   .add('Debounced change', addComponent(<DebouncedChange />))
+  .add('First change', addComponent(<FirstChange />))
 
 /* Validation */
 storiesOf('Validation|Synchronous validation', module)

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -601,7 +601,7 @@ export default class Form extends React.Component {
       fieldUtils.flattenFields,
     )(this.state.fields)
 
-    this.setState({ fields: nextFields }, () => {
+    this.setState({ fields: nextFields, dirty: false }, () => {
       /**
        * Invoke form validation with the predicate that omits empty fields,
        * regardless of their required status. That is to prevent having


### PR DESCRIPTION
Fix `Form.reset()` so that it resets the dirty state of the form. Implement Storybook example and integration tests for `onFirstChange` callback.