### PR TITLE
Sets [valuePropName] key on message resolver arguments

### DIFF
--- a/cypress/integration/validation/messages/ValidationMessages.spec.js
+++ b/cypress/integration/validation/messages/ValidationMessages.spec.js
@@ -100,7 +100,7 @@ describe('Validation messages', function() {
       cy.getField('nameTwo')
         .typeIn('bar')
         .blur()
-        .hasError(messages.name.nameTwo.invalid)
+        .hasError('The name "bar" is invalid.')
 
       cy.getField('nameTwo')
         .clear()

--- a/examples/validation/messages/ValidationMessages.jsx
+++ b/examples/validation/messages/ValidationMessages.jsx
@@ -30,7 +30,7 @@ export const messages = {
     },
     nameTwo: {
       missing: 'Please provide name two',
-      invalid: 'The name two is invalid',
+      invalid: ({ value }) => `The name "${value}" is invalid.`,
     },
   },
 }

--- a/src/utils/validation/messages/getMessages.js
+++ b/src/utils/validation/messages/getMessages.js
@@ -1,4 +1,5 @@
 import * as R from 'ramda'
+import { getValue } from '../../recordUtils'
 import getResolvePaths from './getResolvePaths'
 import resolveMessage from './resolveMessage'
 import pruneMessages from './pruneMessages'
@@ -8,8 +9,12 @@ const createResolveIterator = (
   resolverArgs,
   messagesSchema,
 ) => {
+  console.log({ resolverArgs })
+
+  const { fieldProps } = resolverArgs
   const messageResolverArgs = {
     ...resolverArgs,
+    [fieldProps.valuePropName]: getValue(fieldProps),
     ...validationResult.extra,
   }
 

--- a/src/utils/validation/messages/getMessages.test.js
+++ b/src/utils/validation/messages/getMessages.test.js
@@ -30,6 +30,7 @@ const messagesSchema = {
 
 const fieldOne = recordUtils.createField({
   name: 'fieldOne',
+  fieldPath: ['fieldOne'],
   type: 'email',
   value: 'foo',
 })


### PR DESCRIPTION
## Changes

- Adds missing `[valuePropName]` key in the message resolver arguments
- Adjusts integration test scenario to use a dynamic "value" property in the error message
- Adjusts integration tests to reflect the usage of dynamic "value" property in the error message

## Issues

- Fixes #387 